### PR TITLE
ci: add concurrency groups to cancel outdated PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Automatically cancel in-progress CI runs when new commits are pushed to PR branches, while allowing all runs on main to complete.