### PR TITLE
fix: inconsistent fourmolu versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
 
     haskell-nix = {
       url = "github:input-output-hk/haskell.nix";
-      inputs.hackage.follows = "hackage";
+      inputs = {
+        hackage.follows = "hackage";
+      };
     };
 
     hackage = {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,23 +1,13 @@
 {
-  inputs,
-  pkgs,
   project,
-  system,
   gitHooks,
+  tools,
 }:
 let
   inherit (project.args) compiler-nix-name;
 
   # System tools not tied to GHC version
-  systemTools = with pkgs; [
-    hpack
-    nixfmt-rfc-style
-    postgresql
-    pre-commit
-    sqitchPg
-    sops # secret encryption/decryption
-    age # encryption tool for sops
-  ];
+  systemTools = builtins.attrValues tools;
 in
 project.shellFor {
   name = "hoard-shell-${compiler-nix-name}";
@@ -27,17 +17,6 @@ project.shellFor {
 
   # Enable Hoogle documentation
   withHoogle = true;
-
-  # All tools for the shell
-  tools = {
-    cabal = "latest";
-    fourmolu = "latest";
-    ghcid = "latest";
-    haskell-language-server = "latest";
-    hlint = "latest";
-    tasty-discover = "latest";
-    weeder = "latest";
-  };
 
   buildInputs = systemTools;
 


### PR DESCRIPTION
Using `shellFor`'s `tools` attrset makes `haskell.nix` fetch packages from some pocket dimension. It also does not support setting the version by directly supplying a package derivation, so instead we just supply the tools we need through `buildInputs`.

Closes https://github.com/tweag/cardano-hoarding-node/issues/39