### PR TITLE
fix: incorrect haskell-language-server for the version of GHC we use

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -12,15 +12,9 @@ let
   # Tools and binaries used by git-hooks and in the dev shell
   tools = {
     inherit (pkgs)
-      age
-      cabal-install
       fourmolu
       hlint
       hpack
-      postgresql
-      pre-commit
-      sops
-      sqitchPg
       nixfmt-rfc-style
       ;
   };
@@ -33,13 +27,12 @@ let
     src = ../.;
     hooks = lib.pipe tools [
       (x: x // { hpack = hpack-dir; })
-      (lib.mapAttrs (_: package: { inherit package; }))
-      (lib.recursiveUpdate {
-        hlint.enable = true;
-        hpack.enable = true;
-        nixfmt-rfc-style.enable = true;
-        fourmolu.enable = true;
-      })
+      (lib.mapAttrs (
+        _: package: {
+          inherit package;
+          enable = true;
+        }
+      ))
     ];
   };
 
@@ -55,6 +48,7 @@ in
   # Development shell
   devShells.default = import ./shell.nix {
     inherit
+      pkgs
       project
       gitHooks
       tools

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   project,
   gitHooks,
   tools,
@@ -7,7 +8,15 @@ let
   inherit (project.args) compiler-nix-name;
 
   # System tools not tied to GHC version
-  systemTools = builtins.attrValues tools;
+  systemTools =
+    builtins.attrValues tools
+    ++ (with pkgs; [
+      nixfmt-rfc-style
+      postgresql
+      sqitchPg
+      sops
+      age
+    ]);
 in
 project.shellFor {
   name = "hoard-shell-${compiler-nix-name}";
@@ -19,6 +28,14 @@ project.shellFor {
   withHoogle = true;
 
   buildInputs = systemTools;
+
+  tools = {
+    cabal = "latest";
+    haskell-language-server = "latest";
+    ghcid = "latest";
+    tasty-discover = "latest";
+    weeder = "latest";
+  };
 
   shellHook = ''
     # Git hooks integration


### PR DESCRIPTION
Instead of defining all tools in `outputs.nix`' `tools` attrset, I guess we'll just put the ones that make sense for `git-hooks` in there.