### PR TITLE
refactor: run mini protocols in Eff

### DIFF
--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -32,6 +32,7 @@ import Hoard.Effects.Pub (runPub)
 import Hoard.Effects.Sub (Sub, listen, runSub)
 import Hoard.Network.Events
 
+import Effectful.Prim (runPrim)
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Log qualified as Log
 
@@ -53,6 +54,7 @@ main = withIOManager $ \ioManager -> do
 
     -- Run the test
     result <- runEff
+        . runPrim
         . runLog
         . runConcurrent
         . scoped

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -15,6 +15,7 @@ build-type:     Simple
 
 library
   exposed-modules:
+      Effectful.Instances
       Hoard.API
       Hoard.CLI.Options
       Hoard.Collector
@@ -30,6 +31,8 @@ library
       Hoard.Effects.DBWrite
       Hoard.Effects.Log
       Hoard.Effects.Network
+      Hoard.Effects.Network.Codecs
+      Hoard.Effects.Network.Versions
       Hoard.Effects.Pub
       Hoard.Effects.Sub
       Hoard.Events
@@ -88,6 +91,7 @@ library
     , hasql
     , hasql-pool
     , hasql-transaction
+    , io-classes
     , ki
     , network
     , network-mux
@@ -100,9 +104,11 @@ library
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
+    , primitive
     , rel8
     , servant
     , servant-server
+    , stm
     , string-conversions
     , text
     , time
@@ -160,6 +166,7 @@ executable hoard-exe
     , hasql-pool
     , hasql-transaction
     , hoard
+    , io-classes
     , ki
     , network
     , network-mux
@@ -172,9 +179,11 @@ executable hoard-exe
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
+    , primitive
     , rel8
     , servant
     , servant-server
+    , stm
     , string-conversions
     , text
     , time
@@ -232,6 +241,7 @@ executable test-connection
     , hasql-pool
     , hasql-transaction
     , hoard
+    , io-classes
     , ki
     , network
     , network-mux
@@ -244,9 +254,11 @@ executable test-connection
     , ouroboros-network-api
     , ouroboros-network-framework
     , ouroboros-network-protocols
+    , primitive
     , rel8
     , servant
     , servant-server
+    , stm
     , string-conversions
     , text
     , time
@@ -316,6 +328,7 @@ test-suite hoard-test
     , hoard
     , hspec
     , http-client
+    , io-classes
     , ki
     , network
     , network-mux
@@ -329,12 +342,14 @@ test-suite hoard-test
     , ouroboros-network-framework
     , ouroboros-network-protocols
     , postgres-options
+    , primitive
     , process
     , rel8
     , servant
     , servant-client
     , servant-client-core
     , servant-server
+    , stm
     , string-conversions
     , tasty
     , tasty-discover

--- a/package.yaml
+++ b/package.yaml
@@ -50,13 +50,16 @@ dependencies:
 - hasql
 - hasql-pool
 - hasql-transaction
+- io-classes
 - ki
 - network
 - network-uri
 - optparse-applicative
+- primitive
 - rel8
 - servant
 - servant-server
+- stm
 - string-conversions
 - text
 - time

--- a/src/Effectful/Instances.hs
+++ b/src/Effectful/Instances.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | This module mostly exists to make Effectful's `Eff` compatible with
+-- `io-classes` various `Monad` classes, since those are used extensively by
+-- the `ouroboros` family of packages.
+module Effectful.Instances () where
+
+import Effectful (Eff, (:>))
+
+import Control.Concurrent.STM.TSem qualified as STM
+import Control.Concurrent.STM.TVar qualified as STM
+import Control.Monad.Class.MonadAsync qualified as IOC
+import Control.Monad.Class.MonadFork qualified as IOC
+import Control.Monad.Class.MonadST qualified as IOC
+import Control.Monad.Class.MonadSTM.Internal qualified as IOC
+import Control.Monad.Class.MonadThrow qualified as IOC
+import Control.Monad.Primitive (stToPrim)
+import Effectful.Concurrent qualified as Eff
+import Effectful.Concurrent.Async (Concurrent)
+import Effectful.Concurrent.Async qualified as Eff
+import Effectful.Concurrent.STM qualified as Eff
+import Effectful.Dispatch.Static qualified as Eff
+import Effectful.Exception (BlockedIndefinitelyOnSTM, Exception (..), handle, throwIO)
+import Effectful.Exception qualified as Eff
+import Effectful.Prim (Prim)
+import GHC.Conc.Sync qualified as IO
+import GHC.Stack (CallStack, HasCallStack, callStack, prettyCallStack)
+
+
+newtype EffThreadId es = EffThreadId (Eff.ThreadId)
+    deriving (Show, Eq, Ord) via Eff.ThreadId
+
+
+instance (Concurrent :> es) => IOC.MonadThread (Eff es) where
+    type ThreadId (Eff es) = EffThreadId es
+    myThreadId = EffThreadId <$> Eff.myThreadId
+    labelThread (EffThreadId threadId) x = Eff.unsafeEff_ $ IO.labelThread threadId x
+    threadLabel (EffThreadId threadId) = Eff.unsafeEff_ $ IO.threadLabel threadId
+
+
+newtype EffSTM es a = EffSTM {getEffSTM :: Eff.STM a}
+    deriving (Functor, Applicative, Monad) via Eff.STM
+newtype EffTVar es a = EffTVar {getEffTVar :: Eff.TVar a}
+newtype EffTMVar es a = EffTMVar {getEffTMVar :: Eff.TMVar a}
+newtype EffTQueue es a = EffTQueue {getEffTQueue :: Eff.TQueue a}
+newtype EffTBQueue es a = EffTBQueue {getEffTBQueue :: Eff.TBQueue a}
+data EffTArray es a b
+newtype EffTSem es = EffTSem {getEffTSem :: STM.TSem}
+newtype EffTChan es a = EffTChan {getEffTChan :: Eff.TChan a}
+
+
+instance (Concurrent :> es) => IOC.MonadSTM (Eff es) where
+    type STM (Eff es) = EffSTM es
+    atomically = wrapBlockedIndefinitely . Eff.atomically . getEffSTM
+
+
+    type TVar (Eff es) = EffTVar es
+    type TMVar (Eff es) = EffTMVar es
+    type TQueue (Eff es) = EffTQueue es
+    type TBQueue (Eff es) = EffTBQueue es
+    type TArray (Eff es) = EffTArray es
+    type TSem (Eff es) = EffTSem es
+    type TChan (Eff es) = EffTChan es
+
+
+    newTVar = EffSTM . fmap EffTVar . Eff.newTVar
+    readTVar = EffSTM . Eff.readTVar . getEffTVar
+    writeTVar (EffTVar tvar) x = EffSTM $ Eff.writeTVar tvar x
+    retry = EffSTM Eff.retry
+    orElse (EffSTM a) (EffSTM b) = EffSTM $ Eff.orElse a b
+    check = EffSTM . Eff.check
+
+
+    modifyTVar (EffTVar tvar) f = EffSTM $ Eff.modifyTVar tvar f
+    modifyTVar' (EffTVar tvar) f = EffSTM $ Eff.modifyTVar' tvar f
+    stateTVar (EffTVar tvar) f = EffSTM $ STM.stateTVar tvar f
+    swapTVar (EffTVar tvar) x = EffSTM $ Eff.swapTVar tvar x
+
+
+    newTMVar = EffSTM . fmap EffTMVar . Eff.newTMVar
+    newEmptyTMVar = EffSTM $ EffTMVar <$> Eff.newEmptyTMVar
+    takeTMVar = EffSTM . Eff.takeTMVar . getEffTMVar
+    tryTakeTMVar = EffSTM . Eff.tryTakeTMVar . getEffTMVar
+    putTMVar (EffTMVar tmvar) x = EffSTM $ Eff.putTMVar tmvar x
+    tryPutTMVar (EffTMVar tmvar) x = EffSTM $ Eff.tryPutTMVar tmvar x
+    readTMVar = EffSTM . Eff.readTMVar . getEffTMVar
+    tryReadTMVar = EffSTM . Eff.tryReadTMVar . getEffTMVar
+    swapTMVar (EffTMVar tmvar) x = EffSTM $ Eff.swapTMVar tmvar x
+    writeTMVar (EffTMVar tmvar) x = EffSTM $ Eff.writeTMVar tmvar x
+    isEmptyTMVar = EffSTM . Eff.isEmptyTMVar . getEffTMVar
+
+
+    newTQueue = EffSTM $ EffTQueue <$> Eff.newTQueue
+    readTQueue = EffSTM . Eff.readTQueue . getEffTQueue
+    tryReadTQueue = EffSTM . Eff.tryReadTQueue . getEffTQueue
+    peekTQueue = EffSTM . Eff.peekTQueue . getEffTQueue
+    tryPeekTQueue = EffSTM . Eff.tryPeekTQueue . getEffTQueue
+    flushTQueue = EffSTM . Eff.flushTQueue . getEffTQueue
+    writeTQueue (EffTQueue tqueue) x = EffSTM $ Eff.writeTQueue tqueue x
+    isEmptyTQueue = EffSTM . Eff.isEmptyTQueue . getEffTQueue
+    unGetTQueue (EffTQueue tqueue) x = EffSTM $ Eff.unGetTQueue tqueue x
+
+
+    newTBQueue = EffSTM . fmap EffTBQueue . Eff.newTBQueue
+    readTBQueue = EffSTM . Eff.readTBQueue . getEffTBQueue
+    tryReadTBQueue = EffSTM . Eff.tryReadTBQueue . getEffTBQueue
+    peekTBQueue = EffSTM . Eff.peekTBQueue . getEffTBQueue
+    tryPeekTBQueue = EffSTM . Eff.tryPeekTBQueue . getEffTBQueue
+    writeTBQueue (EffTBQueue tbqueue) x = EffSTM $ Eff.writeTBQueue tbqueue x
+    flushTBQueue = EffSTM . Eff.flushTBQueue . getEffTBQueue
+    lengthTBQueue = EffSTM . Eff.lengthTBQueue . getEffTBQueue
+    isEmptyTBQueue = EffSTM . Eff.isEmptyTBQueue . getEffTBQueue
+    isFullTBQueue = EffSTM . Eff.isFullTBQueue . getEffTBQueue
+    unGetTBQueue (EffTBQueue tbqueue) x = EffSTM $ Eff.unGetTBQueue tbqueue x
+
+
+    newTSem = EffSTM . fmap EffTSem . STM.newTSem
+    waitTSem = EffSTM . STM.waitTSem . getEffTSem
+    signalTSem = EffSTM . STM.signalTSem . getEffTSem
+    signalTSemN n (EffTSem tsem) = EffSTM $ STM.signalTSemN n tsem
+
+
+    newTChan = EffSTM $ EffTChan <$> Eff.newTChan
+    newBroadcastTChan = EffSTM $ EffTChan <$> Eff.newBroadcastTChan
+    dupTChan = EffSTM . fmap EffTChan . Eff.dupTChan . getEffTChan
+    cloneTChan = EffSTM . fmap EffTChan . Eff.cloneTChan . getEffTChan
+    readTChan = EffSTM . Eff.readTChan . getEffTChan
+    tryReadTChan = EffSTM . Eff.tryReadTChan . getEffTChan
+    peekTChan = EffSTM . Eff.peekTChan . getEffTChan
+    tryPeekTChan = EffSTM . Eff.tryPeekTChan . getEffTChan
+    writeTChan (EffTChan tchan) x = EffSTM $ Eff.writeTChan tchan x
+    unGetTChan (EffTChan tchan) x = EffSTM $ Eff.unGetTChan tchan x
+    isEmptyTChan = EffSTM . Eff.isEmptyTChan . getEffTChan
+
+
+    newTVarIO = fmap EffTVar . Eff.newTVarIO
+    readTVarIO = Eff.readTVarIO . getEffTVar
+    newTMVarIO = fmap EffTMVar . Eff.newTMVarIO
+    newEmptyTMVarIO = EffTMVar <$> Eff.newEmptyTMVarIO
+    newTQueueIO = EffTQueue <$> Eff.newTQueueIO
+    newTBQueueIO = fmap EffTBQueue . Eff.newTBQueueIO
+    newTChanIO = EffTChan <$> Eff.newTChanIO
+    newBroadcastTChanIO = EffTChan <$> Eff.newBroadcastTChanIO
+
+
+newtype EffAsync es a = EffAsync {getEffAsync :: Eff.Async a}
+
+
+instance forall es. (Concurrent :> es) => IOC.MonadAsync (Eff es) where
+    type Async (Eff es) = EffAsync es
+    async = fmap EffAsync . Eff.async
+    asyncBound = fmap EffAsync . Eff.asyncBound
+    asyncOn cpu = fmap EffAsync . Eff.asyncOn cpu
+    asyncThreadId (EffAsync a) = EffThreadId $ Eff.asyncThreadId a
+    withAsync action inner = Eff.withAsync action (inner . EffAsync)
+    withAsyncBound action inner = Eff.withAsyncBound action (inner . EffAsync)
+    withAsyncOn cpu action inner = Eff.withAsyncOn cpu action (inner . EffAsync)
+
+
+    waitSTM = EffSTM . Eff.waitSTM . getEffAsync
+    pollSTM = EffSTM . Eff.pollSTM . getEffAsync
+    waitCatchSTM = EffSTM . Eff.waitCatchSTM . getEffAsync
+
+
+    waitAnySTM as = do
+        (a, result) <- EffSTM $ Eff.waitAnySTM (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitAnyCatchSTM as = do
+        (a, result) <- EffSTM $ Eff.waitAnyCatchSTM (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitEitherSTM (EffAsync a) (EffAsync b) = EffSTM $ Eff.waitEitherSTM a b
+    waitEitherSTM_ (EffAsync a) (EffAsync b) = EffSTM $ Eff.waitEitherSTM_ a b
+    waitEitherCatchSTM (EffAsync a) (EffAsync b) = EffSTM $ Eff.waitEitherCatchSTM a b
+    waitBothSTM (EffAsync a) (EffAsync b) = EffSTM $ Eff.waitBothSTM a b
+
+
+    wait (EffAsync a) = Eff.wait a
+    poll (EffAsync a) = Eff.poll a
+    waitCatch (EffAsync a) = Eff.waitCatch a
+    cancel (EffAsync a) = Eff.cancel a
+    cancelWith (EffAsync a) e = Eff.cancelWith a e
+    uninterruptibleCancel (EffAsync a) = Eff.uninterruptibleCancel a
+
+
+    waitAny as = do
+        (a, result) <- Eff.waitAny (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitAnyCatch as = do
+        (a, result) <- Eff.waitAnyCatch (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitAnyCancel as = do
+        (a, result) <- Eff.waitAnyCancel (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitAnyCatchCancel as = do
+        (a, result) <- Eff.waitAnyCatchCancel (map (\(EffAsync x) -> x) as)
+        pure (EffAsync a, result)
+    waitEither (EffAsync a) (EffAsync b) = Eff.waitEither a b
+    waitEitherCatch (EffAsync a) (EffAsync b) = Eff.waitEitherCatch a b
+    waitEitherCancel (EffAsync a) (EffAsync b) = Eff.waitEitherCancel a b
+    waitEitherCatchCancel (EffAsync a) (EffAsync b) = Eff.waitEitherCatchCancel a b
+    waitEither_ (EffAsync a) (EffAsync b) = Eff.waitEither_ a b
+    waitBoth (EffAsync a) (EffAsync b) = Eff.waitBoth a b
+
+
+    race = Eff.race
+    race_ = Eff.race_
+    concurrently = Eff.concurrently
+    concurrently_ = Eff.concurrently_
+
+
+    asyncWithUnmask f = EffAsync <$> Eff.asyncWithUnmask f
+    asyncOnWithUnmask cpu f = EffAsync <$> Eff.asyncOnWithUnmask cpu f
+    withAsyncWithUnmask f inner = Eff.withAsyncWithUnmask f (inner . EffAsync)
+    withAsyncOnWithUnmask cpu f inner = Eff.withAsyncOnWithUnmask cpu f (inner . EffAsync)
+
+
+    compareAsyncs (EffAsync a) (EffAsync b) = Eff.compareAsyncs a b
+
+
+wrapBlockedIndefinitely :: (HasCallStack) => Eff es a -> Eff es a
+wrapBlockedIndefinitely = handle (throwIO . BlockedIndefinitely callStack)
+
+
+--
+
+-- | Wrapper around 'BlockedIndefinitelyOnSTM' that stores a call stack
+data BlockedIndefinitely = BlockedIndefinitely
+    { blockedIndefinitelyCallStack :: CallStack
+    , blockedIndefinitelyException :: BlockedIndefinitelyOnSTM
+    }
+    deriving (Show)
+
+
+instance Exception BlockedIndefinitely where
+    displayException (BlockedIndefinitely cs e) =
+        unlines
+            [ displayException e
+            , prettyCallStack cs
+            ]
+
+
+instance IOC.MonadThrow (Eff es) where
+    throwIO = Eff.throwIO
+    bracket = Eff.bracket
+    bracket_ = Eff.bracket_
+    finally = Eff.finally
+
+
+instance (Prim :> es) => IOC.MonadST (Eff es) where
+    stToIO = stToPrim

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -31,6 +31,7 @@ import Ouroboros.Network.IOManager (IOManager)
 
 import Data.Text qualified as T
 
+import Effectful.Prim (Prim, runPrim)
 import Hoard.Effects.Clock (Clock, runClock)
 import Hoard.Effects.Conc (Conc, runConcWithKi, scoped)
 import Hoard.Effects.DBRead (DBRead, runDBRead)
@@ -65,6 +66,7 @@ data Config = Config
 -- | Constraint alias for application effects
 type AppEff es =
     ( IOE :> es
+    , Prim :> es
     , Log :> es
     , Clock :> es
     , FileSystem :> es
@@ -98,6 +100,7 @@ type AppEffects =
      , FileSystem
      , Clock
      , Log
+     , Prim
      , IOE
      ]
 
@@ -107,6 +110,7 @@ runEffectStack :: (MonadIO m) => Config -> Eff AppEffects a -> m a
 runEffectStack config action = liftIO $ do
     result <-
         runEff
+            . runPrim
             . runLog
             . runClock
             . runFileSystem
@@ -132,6 +136,7 @@ runEffectStackReturningState :: (MonadIO m) => Config -> Eff AppEffects a -> m (
 runEffectStackReturningState config action = liftIO $ do
     result <-
         runEff
+            . runPrim
             . runLog
             . runClock
             . runFileSystem

--- a/src/Hoard/Effects/Network/Codecs.hs
+++ b/src/Hoard/Effects/Network/Codecs.hs
@@ -1,0 +1,100 @@
+module Hoard.Effects.Network.Codecs (defaultCodecs) where
+
+import Codec.CBOR.Decoding (Decoder)
+import Codec.CBOR.Decoding qualified as CBOR
+import Codec.CBOR.Encoding (Encoding)
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Read (DeserialiseFailure)
+import Data.ByteString.Lazy (ByteString)
+import Data.Proxy (Proxy (..))
+import Ouroboros.Consensus.Block (decodeRawHash, encodeRawHash)
+import Ouroboros.Consensus.Network.NodeToNode (Codecs (..))
+import Ouroboros.Consensus.Node.NetworkProtocolVersion (BlockNodeToNodeVersion, NodeToNodeVersion)
+import Ouroboros.Consensus.Node.Run (SerialiseNodeToNodeConstraints)
+import Ouroboros.Consensus.Node.Serialisation (SerialiseNodeToNode, decodeNodeToNode, encodeNodeToNode)
+import Ouroboros.Consensus.Shelley.Ledger.Config (CodecConfig)
+import Ouroboros.Consensus.Util.IOLike (MonadST)
+import Ouroboros.Network.Block (decodePoint, decodeTip, encodePoint, encodeTip)
+import Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetch)
+import Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSync)
+import Ouroboros.Network.Protocol.KeepAlive.Codec (codecKeepAlive_v2)
+import Ouroboros.Network.Protocol.PeerSharing.Codec (codecPeerSharing)
+import Ouroboros.Network.Protocol.TxSubmission2.Codec (codecTxSubmission2)
+
+
+-- | Protocol codecs for the node-to-node protocols
+--
+-- This is a direct copy of the original
+-- `Ouroboros.Consensus.Network.NodeToNode.defaultCodecs` function which
+-- originally includes the superfluous constraint `IOLike`, which we cannot
+-- implement for non-IO monads.
+defaultCodecs
+    :: forall m blk addr
+     . ( SerialiseNodeToNodeConstraints blk
+       , MonadST m
+       )
+    => CodecConfig blk
+    -> BlockNodeToNodeVersion blk
+    -> (NodeToNodeVersion -> addr -> CBOR.Encoding)
+    -> (NodeToNodeVersion -> forall s. CBOR.Decoder s addr)
+    -> NodeToNodeVersion
+    -> Codecs
+        blk
+        addr
+        DeserialiseFailure
+        m
+        ByteString
+        ByteString
+        ByteString
+        ByteString
+        ByteString
+        ByteString
+        ByteString
+defaultCodecs ccfg version encAddr decAddr nodeToNodeVersion =
+    Codecs
+        { cChainSyncCodec =
+            codecChainSync
+                enc
+                dec
+                (encodePoint (encodeRawHash p))
+                (decodePoint (decodeRawHash p))
+                (encodeTip (encodeRawHash p))
+                (decodeTip (decodeRawHash p))
+        , cChainSyncCodecSerialised =
+            codecChainSync
+                enc
+                dec
+                (encodePoint (encodeRawHash p))
+                (decodePoint (decodeRawHash p))
+                (encodeTip (encodeRawHash p))
+                (decodeTip (decodeRawHash p))
+        , cBlockFetchCodec =
+            codecBlockFetch
+                enc
+                dec
+                (encodePoint (encodeRawHash p))
+                (decodePoint (decodeRawHash p))
+        , cBlockFetchCodecSerialised =
+            codecBlockFetch
+                enc
+                dec
+                (encodePoint (encodeRawHash p))
+                (decodePoint (decodeRawHash p))
+        , cTxSubmission2Codec =
+            codecTxSubmission2
+                enc
+                dec
+                enc
+                dec
+        , cKeepAliveCodec = codecKeepAlive_v2
+        , cPeerSharingCodec = codecPeerSharing (encAddr nodeToNodeVersion) (decAddr nodeToNodeVersion)
+        }
+  where
+    p :: Proxy blk
+    p = Proxy
+
+    enc :: (SerialiseNodeToNode blk a) => a -> Encoding
+    enc = encodeNodeToNode ccfg version
+
+    dec :: (SerialiseNodeToNode blk a) => forall s. Decoder s a
+    dec = decodeNodeToNode ccfg version

--- a/src/Hoard/Effects/Network/Versions.hs
+++ b/src/Hoard/Effects/Network/Versions.hs
@@ -1,0 +1,70 @@
+module Hoard.Effects.Network.Versions (unliftVersions) where
+
+import Effectful (Eff, IOE, liftIO, (:>))
+import Effectful.Instances ()
+import Ouroboros.Network.Mux (MiniProtocol (..), MiniProtocolCb (..), OuroborosApplication (..), OuroborosApplicationWithMinimalCtx, RunMiniProtocol (..))
+import Ouroboros.Network.NodeToNode (Versions (..))
+import Ouroboros.Network.Protocol.Handshake.Version (Version (..))
+
+import Data.Map.Strict qualified as M
+import Ouroboros.Network.Channel (Channel (..))
+
+
+-- | A more appropriate name for this might be a "natural transformation" from
+-- `Eff es` to `IO`. The `unlift` function should be supplied by `withRunInIO`
+-- or something along those lines to ensure the `Eff` environment is retained.
+unliftVersions
+    :: (IOE :> es)
+    => (forall x. Eff es x -> IO x)
+    -> Versions v vd (OuroborosApplicationWithMinimalCtx mode addr b (Eff es) a res)
+    -> Versions v vd (OuroborosApplicationWithMinimalCtx mode addr b IO a res)
+unliftVersions unlift (Versions versionMap) = Versions $ M.map (unliftVersion unlift) versionMap
+
+
+unliftVersion
+    :: (IOE :> es)
+    => (forall x. Eff es x -> IO x)
+    -> Version vData (OuroborosApplicationWithMinimalCtx mode addr c (Eff es) a b)
+    -> Version vData (OuroborosApplicationWithMinimalCtx mode addr c IO a b)
+unliftVersion unlift v =
+    Version
+        { versionData = v.versionData
+        , versionApplication = \x ->
+            let
+                OuroborosApplication protocols = v.versionApplication x
+            in
+                OuroborosApplication $ unliftMiniProtocol unlift <$> protocols
+        }
+
+
+unliftMiniProtocol :: (IOE :> es) => (forall x. Eff es x -> IO x) -> MiniProtocol mode iCtx rCtx bytes (Eff es) a b -> MiniProtocol mode iCtx rCtx bytes IO a b
+unliftMiniProtocol unlift prot =
+    MiniProtocol
+        { miniProtocolNum = prot.miniProtocolNum
+        , miniProtocolStart = prot.miniProtocolStart
+        , miniProtocolLimits = prot.miniProtocolLimits
+        , miniProtocolRun = unliftRunMiniProtocol unlift prot.miniProtocolRun
+        }
+
+
+unliftRunMiniProtocol
+    :: (IOE :> es)
+    => (forall x. Eff es x -> IO x)
+    -> RunMiniProtocol mode iCtx rCtx bytes (Eff es) a b
+    -> RunMiniProtocol mode iCtx rCtx bytes IO a b
+unliftRunMiniProtocol unlift = \case
+    InitiatorProtocolOnly cb -> InitiatorProtocolOnly $ unliftMiniProtocolCb unlift cb
+    ResponderProtocolOnly cb -> ResponderProtocolOnly $ unliftMiniProtocolCb unlift cb
+    InitiatorAndResponderProtocol iCb rCb -> InitiatorAndResponderProtocol (unliftMiniProtocolCb unlift iCb) (unliftMiniProtocolCb unlift rCb)
+
+
+unliftMiniProtocolCb
+    :: (IOE :> es)
+    => (forall x. Eff es x -> IO x)
+    -> MiniProtocolCb ctx bytes (Eff es) a
+    -> MiniProtocolCb ctx bytes IO a
+unliftMiniProtocolCb unlift (MiniProtocolCb f) = MiniProtocolCb $ \ctx channel -> unlift $ f ctx (liftChannel channel)
+
+
+liftChannel :: (IOE :> es) => Channel IO a -> Channel (Eff es) a
+liftChannel (Channel send recv) = Channel (liftIO . send) (liftIO recv)

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -11,6 +11,7 @@ import Hasql.Decoders qualified as D
 import Hasql.Encoders qualified as E
 import Hasql.Statement qualified as Statement
 import Hasql.Transaction qualified as TX
+import Hoard.Effects.Log (runLog)
 
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite, runTransaction)


### PR DESCRIPTION
This allows us to use `Eff` directly in mini protocol implementations.

This PR is a bit beefy, since:
- I'm adding a bunch of instances for `Eff` in `Effectful.Instances`.
- I wrote an "unlifting" function for `Versions`, to unlift the contained `Eff` to `IO`, since `connectTo` requires `IO`.
- I copied the `defaultCodecs` implementation straight out of `ouroboros` because their implementation contained a constraint that we cannot create an instance for for `Eff`, namely `IOLike`, which itself has the constraint `MonadBase m m`. Only `IO` satisfies `MonadBase m m` with `MonadBase IO IO`, but `Eff`'s `MonadBase` instance is `MonadBase (Eff es) IO`, which does not satisfy `MonadBase m m`... But in the end, `defaultCodecs` only needed `MonadST`, and not `IOLike`, so we could omit it.

This will allow us to use our logging effect in mini protocol implementations 🙌 

Closes https://github.com/tweag/cardano-hoarding-node/issues/47