### PR TITLE
fix: chain sync overruns its ingress queue limit

### DIFF
--- a/src/Hoard/Effects/Network.hs
+++ b/src/Hoard/Effects/Network.hs
@@ -468,14 +468,11 @@ mkApplication codecs peer publishEvent =
             }
         ]
   where
-    -- Get protocol parameters
     params = defaultMiniProtocolParameters
 
-    -- Protocol limits from parameters
-    -- Using chainSyncPipeliningHighMark as a reasonable default for all protocols
     chainSyncLimits =
         MiniProtocolLimits
-            { maximumIngressQueue = fromIntegral $ chainSyncPipeliningHighMark params
+            { maximumIngressQueue = fromIntegral $ chainSyncPipeliningHighMark params * 4
             }
     blockFetchLimits =
         MiniProtocolLimits


### PR DESCRIPTION
With this, and #56, in place, you will see that chain sync is very chatty 😛 