### PR TITLE
refactor: use IP type for peer addresses

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -47,6 +47,7 @@ library
       Hoard.Types.Environment
       Hoard.Types.Header
       Hoard.Types.HoardState
+      Hoard.Types.NodeIP
       Hoard.Types.QuietSnake
   other-modules:
       Paths_hoard

--- a/src/Hoard/DB/Schemas/Peers.hs
+++ b/src/Hoard/DB/Schemas/Peers.hs
@@ -18,11 +18,12 @@ import Rel8
 import Hoard.DB.Schema (mkSchema)
 import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer (..))
+import Hoard.Types.NodeIP (NodeIP)
 
 
 data Row f = Row
     { id :: Column f (ID Peer)
-    , address :: Column f Text
+    , address :: Column f NodeIP
     , port :: Column f Int32
     , firstDiscovered :: Column f UTCTime
     , lastSeen :: Column f UTCTime

--- a/src/Hoard/Data/Peer.hs
+++ b/src/Hoard/Data/Peer.hs
@@ -5,19 +5,19 @@ module Hoard.Data.Peer
     )
 where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.IP (fromSockAddr)
 import Data.Time (UTCTime)
 import Network.Socket (SockAddr)
 
-import Data.Text qualified as T
-
 import Hoard.Data.ID (ID)
+import Hoard.Types.NodeIP (NodeIP (..))
+import Prelude hiding (id)
 
 
 -- | Represents a peer address (host:port)
 data PeerAddress = PeerAddress
-    { host :: Text
+    { host :: NodeIP
     , port :: Int
     }
     deriving stock (Eq, Generic, Show)
@@ -26,7 +26,7 @@ data PeerAddress = PeerAddress
 -- | Represents a peer in the P2P network
 data Peer = Peer
     { id :: ID Peer
-    , address :: Text
+    , address :: NodeIP
     , port :: Int
     , firstDiscovered :: UTCTime
     , lastSeen :: UTCTime
@@ -34,7 +34,7 @@ data Peer = Peer
     , discoveredVia :: Text
     }
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving (FromJSON, ToJSON)
 
 
 -- | Convert a SockAddr to a PeerAddress
@@ -43,7 +43,7 @@ data Peer = Peer
 -- Returns Nothing for Unix domain sockets or invalid addresses.
 sockAddrToPeerAddress :: SockAddr -> Maybe PeerAddress
 sockAddrToPeerAddress sockAddr = do
-    (ip, portNum) <- fromSockAddr sockAddr
-    let host = T.pack $ show ip
-        port = fromIntegral portNum
+    (host', portNum) <- fromSockAddr sockAddr
+    let port = fromIntegral portNum
+        host = NodeIP host'
     pure PeerAddress {host, port}

--- a/src/Hoard/Effects/PeerRepo.hs
+++ b/src/Hoard/Effects/PeerRepo.hs
@@ -73,7 +73,7 @@ upsertPeersImpl
     -- ^ Timestamp when these peers were discovered
     -> Transaction ()
 upsertPeersImpl peerAddresses sourcePeer timestamp = do
-    let discoveredVia = "PeerSharing:" <> sourcePeer.address <> ":" <> T.pack (show sourcePeer.port)
+    let discoveredVia = "PeerSharing:" <> T.pack (show sourcePeer.address) <> ":" <> T.pack (show sourcePeer.port)
 
     -- Upsert all peers in a single statement
     TX.statement ()

--- a/src/Hoard/Types/NodeIP.hs
+++ b/src/Hoard/Types/NodeIP.hs
@@ -1,0 +1,38 @@
+module Hoard.Types.NodeIP
+    ( NodeIP (..)
+    ) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (String), withText)
+import Data.IP (IP)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics (Generic)
+import Rel8 (DBEq, DBType (..), parseTypeInformation)
+import Text.Read (readMaybe)
+
+
+newtype NodeIP = NodeIP {getNodeIP :: IP}
+    deriving stock (Eq, Ord, Generic)
+    deriving (Show, Read) via (IP)
+
+
+instance FromJSON NodeIP where
+    parseJSON = withText "NodeIP" $ \t ->
+        case readMaybe $ T.unpack t of
+            Just ip -> pure $ NodeIP ip
+            Nothing -> fail "Not a valid IP string"
+
+
+instance ToJSON NodeIP where
+    toJSON = String . T.pack . show . getNodeIP
+
+
+instance DBType NodeIP where
+    typeInformation =
+        parseTypeInformation
+            (maybe (Left "Not a valid IP string") (Right . NodeIP) . readMaybe . T.unpack)
+            (T.pack . show . getNodeIP)
+            (typeInformation @Text)
+
+
+instance DBEq NodeIP

--- a/test/Unit/Hoard/Data/PeerSpec.hs
+++ b/test/Unit/Hoard/Data/PeerSpec.hs
@@ -6,6 +6,7 @@ import Test.Hspec
 import Network.Socket qualified as Socket
 
 import Hoard.Data.Peer (PeerAddress (..), sockAddrToPeerAddress)
+import Text.Read (read)
 
 
 spec_Peer :: Spec
@@ -15,23 +16,23 @@ spec_Peer = describe "Peer address conversion" $ do
             -- 192.168.1.1:3001
             let hostAddr = Socket.tupleToHostAddress (192, 168, 1, 1)
                 sockAddr = SockAddrInet 3001 hostAddr
-            sockAddrToPeerAddress sockAddr `shouldBe` Just (PeerAddress "192.168.1.1" 3001)
+            sockAddrToPeerAddress sockAddr `shouldBe` Just (PeerAddress (read "192.168.1.1") 3001)
 
             -- 10.0.0.1:6000
             let hostAddr2 = Socket.tupleToHostAddress (10, 0, 0, 1)
                 sockAddr2 = SockAddrInet 6000 hostAddr2
-            sockAddrToPeerAddress sockAddr2 `shouldBe` Just (PeerAddress "10.0.0.1" 6000)
+            sockAddrToPeerAddress sockAddr2 `shouldBe` Just (PeerAddress (read "10.0.0.1") 6000)
 
         it "converts IPv6 SockAddr correctly with RFC 5952 zero compression" $ do
             -- ::1 (localhost IPv6) - should compress to ::1
             let hostAddr6 = Socket.tupleToHostAddress6 (0, 0, 0, 0, 0, 0, 0, 1)
                 sockAddr = SockAddrInet6 8080 0 hostAddr6 0
-            sockAddrToPeerAddress sockAddr `shouldBe` Just (PeerAddress "::1" 8080)
+            sockAddrToPeerAddress sockAddr `shouldBe` Just (PeerAddress (read "::1") 8080)
 
             -- 2a05:d014:1cfa:bc01:: - should compress trailing zeros
             let hostAddr6_2 = Socket.tupleToHostAddress6 (0x2a05, 0xd014, 0x1cfa, 0xbc01, 0, 0, 0, 0)
                 sockAddr2 = SockAddrInet6 3001 0 hostAddr6_2 0
-            sockAddrToPeerAddress sockAddr2 `shouldBe` Just (PeerAddress "2a05:d014:1cfa:bc01::" 3001)
+            sockAddrToPeerAddress sockAddr2 `shouldBe` Just (PeerAddress (read "2a05:d014:1cfa:bc01::") 3001)
 
         it "returns Nothing for Unix domain sockets" $ do
             let sockAddr = SockAddrUnix "/tmp/socket"


### PR DESCRIPTION
Converting addresses to mere `Text` makes it so that we have to re-resolve the address when connecting to the peer. It is better to use `Data.IP.IP` to retain that information. A newtype wrapper around `IP` is provided, `NodeIP`, for adding `FromJSON`, `ToJSON` and `Rel8` instances.