### PR TITLE
refactor: derive NodeIP DB and JSON instances from newtypes

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -47,6 +47,7 @@ library
       Hoard.Types.Environment
       Hoard.Types.Header
       Hoard.Types.HoardState
+      Hoard.Types.JsonReadShow
       Hoard.Types.NodeIP
       Hoard.Types.QuietSnake
   other-modules:

--- a/src/Hoard/Types/JsonReadShow.hs
+++ b/src/Hoard/Types/JsonReadShow.hs
@@ -1,0 +1,24 @@
+module Hoard.Types.JsonReadShow (JsonReadShow (..)) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
+import Data.Typeable (typeRep)
+
+
+newtype JsonReadShow a = JsonReadShow {getJsonReadShow :: a}
+
+
+instance forall a. (Typeable a, Read a) => FromJSON (JsonReadShow a) where
+    parseJSON =
+        let
+            typeName = show $ typeRep $ Proxy @a
+        in
+            withText typeName $
+                maybe
+                    (fail $ "Failed to read " <> typeName)
+                    (pure . JsonReadShow)
+                    . readMaybe
+                    . show
+
+
+instance (Show a) => ToJSON (JsonReadShow a) where
+    toJSON = String . show . getJsonReadShow

--- a/src/Hoard/Types/NodeIP.hs
+++ b/src/Hoard/Types/NodeIP.hs
@@ -2,37 +2,14 @@ module Hoard.Types.NodeIP
     ( NodeIP (..)
     ) where
 
-import Data.Aeson (FromJSON (..), ToJSON (..), Value (String), withText)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.IP (IP)
-import Data.Text (Text)
-import Data.Text qualified as T
-import GHC.Generics (Generic)
-import Rel8 (DBEq, DBType (..), parseTypeInformation)
-import Text.Read (readMaybe)
+import Hoard.Types.JsonReadShow (JsonReadShow (..))
+import Rel8 (DBEq, DBType (..), ReadShow (..))
 
 
 newtype NodeIP = NodeIP {getNodeIP :: IP}
     deriving stock (Eq, Ord, Generic)
     deriving (Show, Read) via (IP)
-
-
-instance FromJSON NodeIP where
-    parseJSON = withText "NodeIP" $ \t ->
-        case readMaybe $ T.unpack t of
-            Just ip -> pure $ NodeIP ip
-            Nothing -> fail "Not a valid IP string"
-
-
-instance ToJSON NodeIP where
-    toJSON = String . T.pack . show . getNodeIP
-
-
-instance DBType NodeIP where
-    typeInformation =
-        parseTypeInformation
-            (maybe (Left "Not a valid IP string") (Right . NodeIP) . readMaybe . T.unpack)
-            (T.pack . show . getNodeIP)
-            (typeInformation @Text)
-
-
-instance DBEq NodeIP
+    deriving (DBType, DBEq) via ReadShow NodeIP
+    deriving (FromJSON, ToJSON) via JsonReadShow NodeIP


### PR DESCRIPTION
Inspired by Rel8's `ReadShow`, I wanted something similar for `aeson` classes. Surprisingly, there is no equivalent to `ReadShow` to be used for `FromJSON` and `ToJSON`, so I made `JsonReadShow`. Might come in handy for future types we make as well.