### PR TITLE
refactor: simplify log statements using `relude`'s functions and classes

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -2,7 +2,6 @@ module Main (main) where
 
 import Ouroboros.Network.IOManager (withIOManager)
 
-import Data.Text qualified as T
 import Options.Applicative qualified as Opt
 
 import Hoard.CLI.Options (Options (..), optsParser)
@@ -24,11 +23,11 @@ main = withIOManager $ \ioManager -> do
     -- Determine environment: CLI flag > default to Dev
     let env = fromMaybe Dev options.environment
 
-    putStrLn $ "Loading configuration for environment: " <> show env
+    putTextLn $ "Loading configuration for environment: " <> show env
     config <- loadConfig ioManager env
 
     -- Start background threads in the effect stack
-    putStrLn $ "Starting Hoard on " <> T.unpack config.server.host <> ":" <> show config.server.port <> "..."
+    putTextLn $ "Starting Hoard on " <> config.server.host <> ":" <> show config.server.port <> "..."
     runEffectStack config $ do
         -- Fork the HTTP server
         _ <- Conc.fork $ Server.runServer config

--- a/src/Hoard/CLI/Options.hs
+++ b/src/Hoard/CLI/Options.hs
@@ -5,7 +5,6 @@ module Hoard.CLI.Options
     )
 where
 
-import Data.Text qualified as T
 import Options.Applicative qualified as Opt
 
 import Hoard.Types.Environment (Environment, parseEnvironment)
@@ -32,7 +31,7 @@ parseOptions =
             )
   where
     readEnvironment = Opt.eitherReader $ \s ->
-        case parseEnvironment (T.pack s) of
+        case parseEnvironment (toText s) of
             Just env -> Right env
             Nothing -> Left $ "Invalid environment: " <> s <> ". Must be one of: dev, staging, prod, ci"
 

--- a/src/Hoard/Config/Loader.hs
+++ b/src/Hoard/Config/Loader.hs
@@ -12,7 +12,6 @@ import Ouroboros.Network.IOManager (IOManager)
 import System.FilePath ((</>))
 import System.IO.Error (userError)
 
-import Data.Text qualified as T
 import Data.Yaml qualified as Yaml
 
 import Hoard.Effects (Config (..), ServerConfig (..))
@@ -94,7 +93,7 @@ toDBConfig dbCfg credentials =
 -- Loads both the public config YAML and the secrets YAML file
 loadConfig :: IOManager -> Environment -> IO Config
 loadConfig ioManager env = do
-    let envName = T.unpack $ environmentName env
+    let envName = toString $ environmentName env
 
     -- Load non-sensitive config from YAML
     configFile <- loadYaml @ConfigFile $ "config" </> envName <> ".yaml"

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -28,8 +28,6 @@ import Effectful.State.Static.Shared (State, evalState, runState)
 import Ouroboros.Network.IOManager (IOManager)
 import System.IO.Error (userError)
 
-import Data.Text qualified as T
-
 import Hoard.Effects.Clock (Clock, runClock)
 import Hoard.Effects.Conc (Conc, runConcWithKi, scoped)
 import Hoard.Effects.DBRead (DBRead, runDBRead)
@@ -126,7 +124,7 @@ runEffectStack config action = liftIO $ do
                     . evalState def
                     $ action
     case result of
-        Left err -> throwIO $ userError $ T.unpack err
+        Left err -> throwIO $ userError $ toString err
         Right value -> pure value
 
 
@@ -152,5 +150,5 @@ runEffectStackReturningState config action = liftIO $ do
                     . runState def
                     $ action
     case result of
-        Left err -> throwIO $ userError $ T.unpack err
+        Left err -> throwIO $ userError $ toString err
         Right value -> pure value

--- a/src/Hoard/Effects/DBRead.hs
+++ b/src/Hoard/Effects/DBRead.hs
@@ -11,7 +11,6 @@ import Effectful.Error.Static (Error, throwError)
 import Effectful.TH
 import Hasql.Statement (Statement)
 
-import Data.Text qualified as T
 import Hasql.Pool qualified as Pool
 import Hasql.Session qualified as Session
 
@@ -34,5 +33,5 @@ runDBRead pool = interpret $ \_ -> \case
     RunQuery queryName stmt -> do
         result <- liftIO $ Pool.use pool (Session.statement () stmt)
         case result of
-            Left err -> throwError $ "Query failed: " <> queryName <> " - " <> T.pack (show err)
+            Left err -> throwError $ "Query failed: " <> queryName <> " - " <> show err
             Right value -> pure value

--- a/src/Hoard/Effects/DBWrite.hs
+++ b/src/Hoard/Effects/DBWrite.hs
@@ -11,7 +11,6 @@ import Effectful.Error.Static (Error, throwError)
 import Effectful.TH
 import Hasql.Transaction.Sessions (IsolationLevel (ReadCommitted), Mode (Write), transaction)
 
-import Data.Text qualified as T
 import Hasql.Pool qualified as Pool
 import Hasql.Transaction qualified as Transaction
 
@@ -39,6 +38,6 @@ runDBWrite pool = interpret $ \_ -> \case
         result <- liftIO $ Pool.use pool (transaction ReadCommitted Write tx)
         case result of
             Left err -> do
-                Log.debug $ "DBWrite: " <> txName <> " failed: " <> T.pack (show err)
-                throwError $ "Transaction failed: " <> txName <> " - " <> T.pack (show err)
+                Log.debug $ "DBWrite: " <> txName <> " failed: " <> show err
+                throwError $ "Transaction failed: " <> txName <> " - " <> show err
             Right value -> pure value

--- a/src/Hoard/Effects/Log.hs
+++ b/src/Hoard/Effects/Log.hs
@@ -29,7 +29,11 @@ makeEffect ''Log
 
 runLog :: (IOE :> es) => Eff (Log : es) a -> Eff es a
 runLog = interpret_ $ \case
-    Debug msg -> liftIO $ T.putStrLn $ "[DEBUG] " <> msg
-    Info msg -> liftIO $ T.putStrLn $ "[INFO] " <> msg
-    Warn msg -> liftIO $ T.putStrLn $ "[WARN] " <> msg
-    Err msg -> liftIO $ T.putStrLn $ "[ERROR] " <> msg
+    Debug msg -> log "DEBUG" msg
+    Info msg -> log "INFO" msg
+    Warn msg -> log "WARN" msg
+    Err msg -> log "ERROR" msg
+  where
+    log kind msg = liftIO $ do
+        T.hPutStrLn stdout $ "[" <> kind <> "] " <> msg
+        hFlush stdout

--- a/src/Hoard/Effects/Network.hs
+++ b/src/Hoard/Effects/Network.hs
@@ -71,7 +71,6 @@ import Ouroboros.Network.Snocket (socketSnocket)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Dynamic qualified as Dyn
 import Data.Map.Strict qualified as Map
-import Data.Text qualified as T
 import Debug.Trace qualified
 import Network.TypedProtocol.Peer.Client qualified as Peer
 import Ouroboros.Network.Protocol.ChainSync.Type qualified as ChainSync
@@ -165,7 +164,7 @@ connectToPeerImpl
 connectToPeerImpl ioManager chan protocolConfigPath peer = do
     let addr = IP.toSockAddr (getNodeIP peer.address, fromIntegral peer.port)
     -- Create connection using ouroboros-network
-    Log.debug $ "Attempting connection to " <> T.pack (show addr)
+    Log.debug $ "Attempting connection to " <> show addr
     -- Create a publish callback that can be called from IO
     let publishIO :: forall event. (Typeable event) => event -> IO ()
         publishIO event = writeChan chan (Dyn.toDyn event)
@@ -240,7 +239,7 @@ connectToPeerImpl ioManager chan protocolConfigPath peer = do
 
     case result of
         Left err -> do
-            throwError $ "Failed to connect to peer " <> T.pack (show peer) <> ": " <> T.pack (show err)
+            throwError @Text $ "Failed to connect to peer " <> show peer <> ": " <> show err
         Right (Left ()) -> do
             -- Connection succeeded, create Connection record
             timestamp <- liftIO getCurrentTime
@@ -332,19 +331,19 @@ loadProtocolInfo configPath = do
 --------------------------------------------------------------------------------
 
 -- | Wrap a protocol action with exception logging to debug cancellations.
-withExceptionLogging :: String -> IO a -> IO a
+withExceptionLogging :: Text -> IO a -> IO a
 withExceptionLogging protocolName action =
     action `catch` \(e :: SomeException) -> do
         case fromException e of
             Just ThreadKilled -> do
-                putStrLn $ "[EXCEPTION] " <> protocolName <> " killed: ThreadKilled"
-                putStrLn $ "[EXCEPTION] " <> protocolName <> " - This is likely due to the Ki scope cleanup or connection closure"
+                putTextLn $ "[EXCEPTION] " <> protocolName <> " killed: ThreadKilled"
+                putTextLn $ "[EXCEPTION] " <> protocolName <> " - This is likely due to the Ki scope cleanup or connection closure"
             Just UserInterrupt -> do
-                putStrLn $ "[EXCEPTION] " <> protocolName <> " interrupted: UserInterrupt"
+                putTextLn $ "[EXCEPTION] " <> protocolName <> " interrupted: UserInterrupt"
             Just (asyncEx :: AsyncException) -> do
-                putStrLn $ "[EXCEPTION] " <> protocolName <> " async exception: " <> show asyncEx
+                putTextLn $ "[EXCEPTION] " <> protocolName <> " async exception: " <> show asyncEx
             Nothing -> do
-                putStrLn $ "[EXCEPTION] " <> protocolName <> " terminated with exception: " <> show e
+                putTextLn $ "[EXCEPTION] " <> protocolName <> " terminated with exception: " <> show e
         -- Re-throw the exception after logging
         throwIO e
 
@@ -383,11 +382,11 @@ mkApplication codecs peer publishEvent =
             , miniProtocolStart = StartEagerly
             , miniProtocolRun = InitiatorProtocolOnly $ MiniProtocolCb $ \_ctx _channel ->
                 withExceptionLogging "BlockFetch" $ do
-                    putStrLn "[DEBUG] BlockFetch protocol stub started - will sleep forever to keep connection alive"
+                    putTextLn "[DEBUG] BlockFetch protocol stub started - will sleep forever to keep connection alive"
                     -- Sleep forever instead of terminating immediately
                     -- This prevents the stub from signaling connection termination
                     threadDelay maxBound
-                    putStrLn "[DEBUG] BlockFetch stub woke up (should never happen)"
+                    putTextLn "[DEBUG] BlockFetch stub woke up (should never happen)"
                     pure ((), Nothing)
             }
         , -- KeepAlive mini-protocol
@@ -403,7 +402,7 @@ mkApplication codecs peer publishEvent =
                                 wrappedPeer = Peer.Effect $
                                     withExceptionLogging "KeepAlive" $
                                         do
-                                            putStrLn "[DEBUG] KeepAlive protocol started"
+                                            putTextLn "[DEBUG] KeepAlive protocol started"
                                             pure (keepAliveClientPeer keepAliveClientImpl)
                                 tracer = contramap (("[KeepAlive] " <>) . show) stdoutTracer
                             in  (tracer, codec, wrappedPeer)
@@ -423,8 +422,8 @@ mkApplication codecs peer publishEvent =
                                 wrappedPeer = Peer.Effect $ withExceptionLogging "PeerSharing" $ do
                                     timestamp <- getCurrentTime
                                     publishEvent $ PeerSharingStarted PeerSharingStartedData {peer, timestamp}
-                                    putStrLn "[DEBUG] PeerSharing: Published PeerSharingStarted event"
-                                    putStrLn "[DEBUG] PeerSharing: About to run peer protocol..."
+                                    putTextLn "[DEBUG] PeerSharing: Published PeerSharingStarted event"
+                                    putTextLn "[DEBUG] PeerSharing: About to run peer protocol..."
                                     pure (peerSharingClientPeer client)
                                 tracer = contramap (("[PeerSharing] " <>) . show) stdoutTracer
                             in  (tracer, codec, wrappedPeer)
@@ -436,11 +435,11 @@ mkApplication codecs peer publishEvent =
             , miniProtocolStart = StartEagerly
             , miniProtocolRun = InitiatorProtocolOnly $ MiniProtocolCb $ \_ctx _channel ->
                 withExceptionLogging "TxSubmission" $ do
-                    putStrLn "[DEBUG] TxSubmission protocol stub started - will sleep forever to keep connection alive"
+                    putTextLn "[DEBUG] TxSubmission protocol stub started - will sleep forever to keep connection alive"
                     -- Sleep forever instead of terminating immediately
                     -- This prevents the stub from signaling connection termination
                     threadDelay maxBound
-                    putStrLn "[DEBUG] TxSubmission stub woke up (should never happen)"
+                    putTextLn "[DEBUG] TxSubmission stub woke up (should never happen)"
                     pure ((), Nothing)
             }
         ]
@@ -490,8 +489,8 @@ peerSharingClientImpl peer publishEvent =
   where
     requestPeers = PeerSharing.SendMsgShareRequest $ PeerSharingAmount 100
     withPeers peerAddrs = do
-        putStrLn "[DEBUG] PeerSharing: *** CALLBACK EXECUTED - GOT RESPONSE ***"
-        putStrLn $ "[DEBUG] PeerSharing: Received response with " <> show (length peerAddrs) <> " peers"
+        putTextLn "[DEBUG] PeerSharing: *** CALLBACK EXECUTED - GOT RESPONSE ***"
+        putTextLn $ "[DEBUG] PeerSharing: Received response with " <> show (length peerAddrs) <> " peers"
         timestamp <- getCurrentTime
         publishEvent $
             PeersReceived
@@ -500,10 +499,10 @@ peerSharingClientImpl peer publishEvent =
                     , peerAddresses = mapMaybe sockAddrToPeerAddress peerAddrs
                     , timestamp
                     }
-        putStrLn "[DEBUG] PeerSharing: Published PeersReceived event"
-        putStrLn "[DEBUG] PeerSharing: Waiting 10 seconds"
+        putTextLn "[DEBUG] PeerSharing: Published PeersReceived event"
+        putTextLn "[DEBUG] PeerSharing: Waiting 10 seconds"
         threadDelay oneHour
-        putStrLn "[DEBUG] PeerSharing: looping"
+        putTextLn "[DEBUG] PeerSharing: looping"
         pure $ requestPeers withPeers
     oneHour = 3_600_000_000
 
@@ -529,18 +528,18 @@ chainSyncClientImpl peer publishEvent =
                     -- Publish started event
                     timestamp <- getCurrentTime
                     publishEvent $ ChainSyncStarted ChainSyncStartedData {peer, timestamp}
-                    putStrLn "[DEBUG] ChainSync: Published ChainSyncStarted event"
-                    putStrLn "[DEBUG] ChainSync: Starting pipelined client, finding intersection from genesis"
+                    putTextLn "[DEBUG] ChainSync: Published ChainSyncStarted event"
+                    putTextLn "[DEBUG] ChainSync: Starting pipelined client, finding intersection from genesis"
                     pure findIntersect
   where
     findIntersect :: forall c. Client (ChainSync Header' Point' Tip') (Pipelined Z c) ChainSync.StIdle IO ()
     findIntersect =
         Yield (ChainSync.MsgFindIntersect [genesisPoint]) $ Await $ \case
             ChainSync.MsgIntersectNotFound {} -> Effect $ do
-                putStrLn "[DEBUG] ChainSync: Intersection not found (continuing anyway)"
+                putTextLn "[DEBUG] ChainSync: Intersection not found (continuing anyway)"
                 pure requestNext
             ChainSync.MsgIntersectFound intersectPt tip -> Effect $ do
-                putStrLn "[DEBUG] ChainSync: Intersection found"
+                putTextLn "[DEBUG] ChainSync: Intersection found"
                 timestamp <- getCurrentTime
                 publishEvent $
                     ChainSyncIntersectionFound
@@ -556,7 +555,7 @@ chainSyncClientImpl peer publishEvent =
     requestNext =
         Yield ChainSync.MsgRequestNext $ Await $ \case
             ChainSync.MsgRollForward hdr tip -> Effect $ do
-                putStrLn "[DEBUG] ChainSync: Received header (RollForward)"
+                putTextLn "[DEBUG] ChainSync: Received header (RollForward)"
                 timestamp <- getCurrentTime
                 let hdrPoint = castPoint $ headerPoint hdr
                 publishEvent $
@@ -571,7 +570,7 @@ chainSyncClientImpl peer publishEvent =
                             }
                 pure requestNext
             ChainSync.MsgRollBackward rollbackPt tip -> Effect $ do
-                putStrLn "[DEBUG] ChainSync: Rollback"
+                putTextLn "[DEBUG] ChainSync: Rollback"
                 timestamp <- getCurrentTime
                 publishEvent $
                     RollBackward
@@ -584,7 +583,7 @@ chainSyncClientImpl peer publishEvent =
                 pure requestNext
             ChainSync.MsgAwaitReply -> Await $ \case
                 ChainSync.MsgRollForward hdr tip -> Effect $ do
-                    putStrLn "[DEBUG] ChainSync: Received header after await (RollForward)"
+                    putTextLn "[DEBUG] ChainSync: Received header after await (RollForward)"
                     timestamp <- getCurrentTime
                     let hdrPoint = castPoint $ headerPoint hdr
                     publishEvent $
@@ -598,7 +597,7 @@ chainSyncClientImpl peer publishEvent =
                                 }
                     pure requestNext
                 ChainSync.MsgRollBackward rollbackPt tip -> Effect $ do
-                    putStrLn "[DEBUG] ChainSync: Rollback after await"
+                    putTextLn "[DEBUG] ChainSync: Rollback after await"
                     timestamp <- getCurrentTime
                     publishEvent $
                         RollBackward
@@ -621,12 +620,12 @@ keepAliveClientImpl = KeepAliveClient sendFirst
   where
     -- Send the first message immediately
     sendFirst = do
-        putStrLn "[DEBUG] KeepAlive: Sending first keepalive message"
+        putTextLn "[DEBUG] KeepAlive: Sending first keepalive message"
         pure $ SendMsgKeepAlive (Cookie 42) sendNext
 
     -- Wait 10 seconds before sending subsequent messages
     sendNext = do
-        putStrLn "[DEBUG] KeepAlive: Response received, waiting 10s before next message"
+        putTextLn "[DEBUG] KeepAlive: Response received, waiting 10s before next message"
         threadDelay 10_000_000 -- 10 seconds in microseconds
-        putStrLn "[DEBUG] KeepAlive: Sending keepalive message"
+        putTextLn "[DEBUG] KeepAlive: Sending keepalive message"
         pure $ SendMsgKeepAlive (Cookie 42) sendNext

--- a/src/Hoard/Effects/PeerRepo.hs
+++ b/src/Hoard/Effects/PeerRepo.hs
@@ -11,7 +11,6 @@ import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret)
 import Effectful.TH (makeEffect)
 
-import Data.Text qualified as T
 import Hasql.Statement (Statement)
 import Hasql.Transaction (Transaction)
 import Hasql.Transaction qualified as TX
@@ -73,7 +72,7 @@ upsertPeersImpl
     -- ^ Timestamp when these peers were discovered
     -> Transaction ()
 upsertPeersImpl peerAddresses sourcePeer timestamp = do
-    let discoveredVia = "PeerSharing:" <> T.pack (show sourcePeer.address) <> ":" <> T.pack (show sourcePeer.port)
+    let discoveredVia = "PeerSharing:" <> show sourcePeer.address <> ":" <> show sourcePeer.port
 
     -- Upsert all peers in a single statement
     TX.statement ()

--- a/src/Hoard/Listeners/HeaderReceivedListener.hs
+++ b/src/Hoard/Listeners/HeaderReceivedListener.hs
@@ -1,9 +1,7 @@
 module Hoard.Listeners.HeaderReceivedListener (headerReceivedListener) where
 
 import Effectful (Eff, (:>))
-import Prelude hiding (putStrLn)
 
-import Data.Text qualified as T
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Events.HeaderReceived (HeaderReceived (..))
@@ -13,4 +11,4 @@ import Hoard.Events.HeaderReceived (HeaderReceived (..))
 headerReceivedListener :: (Log :> es) => HeaderReceived -> Eff es ()
 headerReceivedListener event = do
     Log.debug "Header received:"
-    Log.debug $ T.pack $ show event
+    Log.debug $ show event

--- a/src/Hoard/Listeners/PeersReceivedListener.hs
+++ b/src/Hoard/Listeners/PeersReceivedListener.hs
@@ -1,7 +1,6 @@
 module Hoard.Listeners.PeersReceivedListener (peersReceivedListener) where
 
 import Effectful (Eff, (:>))
-import Prelude hiding (putStrLn)
 
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Network.Events (PeerSharingEvent (..), PeersReceivedData (..))

--- a/src/Hoard/Server.hs
+++ b/src/Hoard/Server.hs
@@ -6,9 +6,6 @@ where
 import Effectful (Eff)
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 import Servant
-import Prelude hiding (putStrLn)
-
-import Data.Text qualified as T
 
 import Hoard.API (API, server)
 import Hoard.Effects (AppEff, Config (..), ServerConfig (..), runEffectStack)
@@ -21,9 +18,9 @@ runServer :: (AppEff es) => Config -> Eff es ()
 runServer config = do
     -- Log startup messages
     let ServerConfig {host = serverHost, port = serverPort} = config.server
-        host = T.unpack serverHost
+        host = toString serverHost
         port = fromIntegral serverPort
-    Log.debug $ "Starting Hoard server on " <> T.pack host <> ":" <> T.pack (show port)
+    Log.debug $ "Starting Hoard server on " <> toText host <> ":" <> show port
     Log.debug "Waiting for data..."
 
     -- Run Warp server (needs liftIO since Warp's runSettings is in IO)

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -7,7 +7,6 @@ where
 
 import Data.Aeson (FromJSON (..), withText)
 import Data.String.Conversions (cs)
-
 import Data.Text qualified as T
 
 
@@ -29,7 +28,7 @@ instance IsString Environment where
 instance FromJSON Environment where
     parseJSON = withText "Environment" $ \x -> case parseEnvironment x of
         Just env -> pure env
-        Nothing -> fail $ "Invalid environment: " <> T.unpack x
+        Nothing -> fail $ "Invalid environment: " <> toString x
 
 
 -- | Parse environment from a string

--- a/test/Hoard/TestHelpers/Database.hs
+++ b/test/Hoard/TestHelpers/Database.hs
@@ -172,11 +172,11 @@ runSqitchMigrations config dbName = do
     -- Build sqitch connection string based on whether we're using TCP or socket
     let targetUri =
             "db:pg://"
-                <> Text.unpack config.user
+                <> toString config.user
                 <> "@/"
-                <> Text.unpack dbName
+                <> toString dbName
                 <> "?host="
-                <> Text.unpack config.host
+                <> toString config.host
                 <> "&port="
                 <> show config.port
         args = ["deploy", targetUri]

--- a/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
@@ -5,7 +5,6 @@ import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Test.Hspec
 
-import Data.Text qualified as T
 import Data.UUID.V4 qualified as UUID
 import Hasql.Statement (Statement)
 import Rel8 qualified
@@ -98,7 +97,7 @@ spec_PeerPersistence = do
                     -- firstDiscovered should still be the original time
                     abs (diffTime peer.firstDiscovered now) `shouldSatisfy` (< 1)
                     -- discoveredVia should be unchanged
-                    peer.discoveredVia `shouldBe` ("PeerSharing:" <> T.pack (show sourcePeer.address) <> ":" <> T.pack (show sourcePeer.port))
+                    peer.discoveredVia `shouldBe` ("PeerSharing:" <> show sourcePeer.address <> ":" <> show sourcePeer.port)
                 Left err -> expectationFailure $ "Peer query failed: " <> show err
 
         it "handles multiple peers in one batch" $ \config -> do
@@ -146,7 +145,7 @@ spec_PeerPersistence = do
                     -- Verify the peer data matches what we inserted
                     peer.address `shouldBe` testAddr.host
                     peer.port `shouldBe` testAddr.port
-                    peer.discoveredVia `shouldBe` ("PeerSharing:" <> T.pack (show sourcePeer.address) <> ":" <> T.pack (show sourcePeer.port))
+                    peer.discoveredVia `shouldBe` ("PeerSharing:" <> show sourcePeer.address <> ":" <> show sourcePeer.port)
                     -- Timestamps should be close to what we inserted
                     abs (diffTime peer.firstDiscovered now) `shouldSatisfy` (< 1)
                     abs (diffTime peer.lastSeen now) `shouldSatisfy` (< 1)


### PR DESCRIPTION
Just tidying up a decent amount of log statements
- Since `relude`'s `show`'s resulting value is generic over `relude`'s `IsString`, for which `Text` has an instance. In other words, `relude`'s `show` can produce `Text`, so we don't need to do `T.pack (show x)`.
- `relude` includes `toText` and `toString` to convert between `Text` and `String` easily, so we can omit importing `Data.Text` to use `T.pack` and `T.unpack`.