### PR TITLE
fix: cannot resolve preview relay address

### DIFF
--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -182,7 +182,7 @@ chainSyncEventListener = listen $ \event -> do
 resolvePeerAddress :: Text -> Int -> IO (IP, PortNumber)
 resolvePeerAddress address port = do
     let hints = Socket.defaultHints {Socket.addrSocketType = Socket.Stream}
-    addrs <- Socket.getAddrInfo (Just hints) (Just $ show address) (Just $ show port)
+    addrs <- Socket.getAddrInfo (Just hints) (Just $ toString address) (Just $ show port)
     case addrs of
         (addr :| _) ->
             maybe (error "Found address of preview relay is not an IP address") pure $


### PR DESCRIPTION
When you `show` a string, extra quotes are added, so `getAddrInfo` could not resolve the string `"\"<addr>\""`.