### PR TITLE
refactor: use PeerAddress when connecting to peers and in events

### DIFF
--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -82,8 +82,7 @@ mkPreviewRelay = do
     pure
         Peer
             { id = id'
-            , address = NodeIP ip
-            , port = fromIntegral portNumber
+            , address = PeerAddress (NodeIP ip) (fromIntegral portNumber)
             , firstDiscovered = now
             , lastSeen = now
             , lastConnected = Nothing
@@ -97,7 +96,7 @@ testConnection
     => Eff es ()
 testConnection = do
     previewRelay <- liftIO mkPreviewRelay
-    Log.info $ "Connecting to " <> show previewRelay.address <> ":" <> show previewRelay.port
+    Log.info $ "Connecting to " <> show previewRelay.address.host <> ":" <> show previewRelay.address.port
 
     -- Start event listeners in background
     Conc.fork_ networkEventListener
@@ -105,7 +104,7 @@ testConnection = do
     Conc.fork_ chainSyncEventListener
 
     -- Connect to peer
-    conn <- connectToPeer previewRelay
+    conn <- connectToPeer previewRelay.address
 
     Log.info "✓ Connection established!"
 

--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -3,7 +3,7 @@ module Hoard.Collector (dispatchDiscoveredNodes, runCollector) where
 import Control.Concurrent (threadDelay)
 import Effectful (Eff, IOE, (:>))
 
-import Hoard.Data.Peer (Peer)
+import Hoard.Data.Peer (PeerAddress)
 import Hoard.Effects.Conc (Conc, fork_)
 import Hoard.Effects.Network (Network, connectToPeer)
 import Hoard.Effects.Pub (Pub, publish)
@@ -21,7 +21,7 @@ dispatchDiscoveredNodes = listen $ \(NodeDiscovered peer) ->
 
 runCollector
     :: (IOE :> es, Network :> es, Pub :> es)
-    => Peer
+    => PeerAddress
     -> Eff es Void
 runCollector peer = do
     publish $ CollectorStarted peer

--- a/src/Hoard/DB/Schemas/Peers.hs
+++ b/src/Hoard/DB/Schemas/Peers.hs
@@ -17,7 +17,7 @@ import Rel8
 
 import Hoard.DB.Schema (mkSchema)
 import Hoard.Data.ID (ID)
-import Hoard.Data.Peer (Peer (..))
+import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Types.NodeIP (NodeIP)
 
 
@@ -50,8 +50,7 @@ peerFromRow :: Row Result -> Peer
 peerFromRow row =
     Peer
         { id = row.id
-        , address = row.address
-        , port = fromIntegral row.port
+        , address = PeerAddress row.address (fromIntegral row.port)
         , firstDiscovered = row.firstDiscovered
         , lastSeen = row.lastSeen
         , lastConnected = row.lastConnected
@@ -64,8 +63,8 @@ rowFromPeer :: Peer -> Row Result
 rowFromPeer peer =
     Row
         { id = peer.id
-        , address = peer.address
-        , port = fromIntegral peer.port
+        , address = peer.address.host
+        , port = fromIntegral peer.address.port
         , firstDiscovered = peer.firstDiscovered
         , lastSeen = peer.lastSeen
         , lastConnected = peer.lastConnected

--- a/src/Hoard/Data/Peer.hs
+++ b/src/Hoard/Data/Peer.hs
@@ -2,14 +2,15 @@ module Hoard.Data.Peer
     ( Peer (..)
     , PeerAddress (..)
     , sockAddrToPeerAddress
+    , peerAddressToSockAddr
     )
 where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
-import Data.IP (fromSockAddr)
 import Data.Time (UTCTime)
 import Network.Socket (SockAddr)
 
+import Data.IP qualified as IP
 import Hoard.Data.ID (ID)
 import Hoard.Types.NodeIP (NodeIP (..))
 import Prelude hiding (id)
@@ -20,14 +21,14 @@ data PeerAddress = PeerAddress
     { host :: NodeIP
     , port :: Int
     }
-    deriving stock (Eq, Generic, Show)
+    deriving stock (Eq, Ord, Generic, Show)
+    deriving (FromJSON, ToJSON)
 
 
 -- | Represents a peer in the P2P network
 data Peer = Peer
     { id :: ID Peer
-    , address :: NodeIP
-    , port :: Int
+    , address :: PeerAddress
     , firstDiscovered :: UTCTime
     , lastSeen :: UTCTime
     , lastConnected :: Maybe UTCTime
@@ -43,7 +44,12 @@ data Peer = Peer
 -- Returns Nothing for Unix domain sockets or invalid addresses.
 sockAddrToPeerAddress :: SockAddr -> Maybe PeerAddress
 sockAddrToPeerAddress sockAddr = do
-    (host', portNum) <- fromSockAddr sockAddr
+    (host', portNum) <- IP.fromSockAddr sockAddr
     let port = fromIntegral portNum
         host = NodeIP host'
     pure PeerAddress {host, port}
+
+
+peerAddressToSockAddr :: PeerAddress -> SockAddr
+peerAddressToSockAddr addr =
+    IP.toSockAddr (getNodeIP addr.host, fromIntegral $ addr.port)

--- a/src/Hoard/Events/Collector.hs
+++ b/src/Hoard/Events/Collector.hs
@@ -2,14 +2,14 @@ module Hoard.Events.Collector
     ( CollectorEvent (..)
     ) where
 
-import Hoard.Data.Peer (Peer)
+import Hoard.Data.Peer (PeerAddress)
 
 
 data CollectorEvent
-    = CollectorStarted Peer
-    | ConnectingToPeer Peer
-    | ConnectedToPeer Peer
-    | ConnectionFailed Peer Text
-    | ChainSyncReceived Peer
-    | BlockFetchReceived Peer
+    = CollectorStarted PeerAddress
+    | ConnectingToPeer PeerAddress
+    | ConnectedToPeer PeerAddress
+    | ConnectionFailed PeerAddress Text
+    | ChainSyncReceived PeerAddress
+    | BlockFetchReceived PeerAddress
     deriving (Show, Typeable)

--- a/src/Hoard/Events/Node.hs
+++ b/src/Hoard/Events/Node.hs
@@ -1,7 +1,7 @@
 module Hoard.Events.Node (NodeDiscovered (..)) where
 
-import Hoard.Data.Peer (Peer)
+import Hoard.Data.Peer (PeerAddress)
 
 
-newtype NodeDiscovered = NodeDiscovered Peer
+newtype NodeDiscovered = NodeDiscovered PeerAddress
     deriving (Show, Typeable)

--- a/src/Hoard/Network/Events.hs
+++ b/src/Hoard/Network/Events.hs
@@ -42,7 +42,7 @@ import Ouroboros.Consensus.Cardano.Block (CardanoBlock, Header, StandardCrypto)
 import Ouroboros.Network.Block (Point, Tip)
 import Ouroboros.Network.NodeToNode (NodeToNodeVersion)
 
-import Hoard.Data.Peer (Peer, PeerAddress)
+import Hoard.Data.Peer (PeerAddress)
 
 
 -- | Type aliases for Cardano block types used throughout the network events.
@@ -74,7 +74,7 @@ data NetworkEvent
 
 
 data ConnectionEstablishedData = ConnectionEstablishedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , version :: NodeToNodeVersion
     , timestamp :: UTCTime
     }
@@ -82,7 +82,7 @@ data ConnectionEstablishedData = ConnectionEstablishedData
 
 
 data ConnectionLostData = ConnectionLostData
-    { peer :: Peer
+    { peer :: PeerAddress
     , reason :: Text
     , timestamp :: UTCTime
     }
@@ -90,7 +90,7 @@ data ConnectionLostData = ConnectionLostData
 
 
 data HandshakeCompletedData = HandshakeCompletedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , version :: NodeToNodeVersion
     , timestamp :: UTCTime
     }
@@ -98,7 +98,7 @@ data HandshakeCompletedData = HandshakeCompletedData
 
 
 data ProtocolErrorData = ProtocolErrorData
-    { peer :: Peer
+    { peer :: PeerAddress
     , errorMessage :: Text
     , timestamp :: UTCTime
     }
@@ -123,14 +123,14 @@ data ChainSyncEvent
 
 
 data ChainSyncStartedData = ChainSyncStartedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , timestamp :: UTCTime
     }
     deriving (Show, Typeable)
 
 
 data HeaderReceivedData = HeaderReceivedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , header :: Header'
     , point :: Point'
     , tip :: Tip'
@@ -140,7 +140,7 @@ data HeaderReceivedData = HeaderReceivedData
 
 
 data RollBackwardData = RollBackwardData
-    { peer :: Peer
+    { peer :: PeerAddress
     , point :: Point'
     , tip :: Tip'
     , timestamp :: UTCTime
@@ -149,7 +149,7 @@ data RollBackwardData = RollBackwardData
 
 
 data RollForwardData = RollForwardData
-    { peer :: Peer
+    { peer :: PeerAddress
     , header :: Header'
     , point :: Point'
     , tip :: Tip'
@@ -159,7 +159,7 @@ data RollForwardData = RollForwardData
 
 
 data ChainSyncIntersectionFoundData = ChainSyncIntersectionFoundData
-    { peer :: Peer
+    { peer :: PeerAddress
     , point :: Point'
     , tip :: Tip'
     , timestamp :: UTCTime
@@ -185,14 +185,14 @@ data BlockFetchEvent
 
 
 data BlockFetchStartedData = BlockFetchStartedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , timestamp :: UTCTime
     }
     deriving (Show, Typeable)
 
 
 data BlockRequestedData = BlockRequestedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , point :: Point'
     , timestamp :: UTCTime
     }
@@ -200,7 +200,7 @@ data BlockRequestedData = BlockRequestedData
 
 
 data BlockReceivedData = BlockReceivedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , block :: CardanoBlock'
     , timestamp :: UTCTime
     }
@@ -208,7 +208,7 @@ data BlockReceivedData = BlockReceivedData
 
 
 data BlockFetchFailedData = BlockFetchFailedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , point :: Point'
     , errorMessage :: Text
     , timestamp :: UTCTime
@@ -217,7 +217,7 @@ data BlockFetchFailedData = BlockFetchFailedData
 
 
 data BlockBatchCompletedData = BlockBatchCompletedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , blockCount :: Int
     , timestamp :: UTCTime
     }
@@ -240,22 +240,22 @@ data PeerSharingEvent
 
 
 data PeerSharingStartedData = PeerSharingStartedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , timestamp :: UTCTime
     }
     deriving (Show, Typeable)
 
 
 data PeersReceivedData = PeersReceivedData
-    { peer :: Peer -- The peer we requested from
-    , peerAddresses :: [PeerAddress] -- The peer addresses we received
+    { peer :: PeerAddress -- The peer we requested from
+    , peerAddresses :: Set PeerAddress -- The peer addresses we received
     , timestamp :: UTCTime
     }
     deriving (Show, Typeable)
 
 
 data PeerSharingFailedData = PeerSharingFailedData
-    { peer :: Peer
+    { peer :: PeerAddress
     , errorMessage :: Text
     , timestamp :: UTCTime
     }

--- a/src/Hoard/Network/Types.hs
+++ b/src/Hoard/Network/Types.hs
@@ -11,7 +11,7 @@ module Hoard.Network.Types
 import Data.Time (UTCTime)
 import Ouroboros.Network.NodeToNode (NodeToNodeVersion)
 
-import Hoard.Data.Peer (Peer)
+import Hoard.Data.Peer (PeerAddress)
 
 
 --------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ import Hoard.Data.Peer (Peer)
 --   liftIO $ putStrLn $ "Protocol version: " <> show conn.version
 -- @
 data Connection = Connection
-    { peer :: Peer
+    { peer :: PeerAddress
     -- ^ The peer this connection is established with
     , version :: NodeToNodeVersion
     -- ^ The negotiated node-to-node protocol version

--- a/src/Hoard/Types/HoardState.hs
+++ b/src/Hoard/Types/HoardState.hs
@@ -4,12 +4,12 @@ import Data.Default (Default (..))
 
 import Data.Set qualified as S
 
-import Hoard.Types.Collector (Peer)
+import Hoard.Data.Peer (PeerAddress)
 
 
 -- | Application state
 data HoardState = HoardState
-    { peers :: Set Peer
+    { connectedPeers :: Set PeerAddress
     }
     deriving (Eq, Show)
 
@@ -17,5 +17,5 @@ data HoardState = HoardState
 instance Default HoardState where
     def =
         HoardState
-            { peers = S.empty
+            { connectedPeers = S.empty
             }


### PR DESCRIPTION
As `Peer`s are modeled now, it seems most sensible for the DB logic to be responsible for creating new `Peer` records. The rest of the application has no extra need for anything but the `PeerAddress` of the peer, so they can restrict their arguments as such, which also simplifies publishing and consuming peer events.

Depends on #68 