### PR TITLE
refactor: rename chain types

### DIFF
--- a/src/Hoard/Effects/Network.hs
+++ b/src/Hoard/Effects/Network.hs
@@ -86,15 +86,15 @@ import Hoard.Network.Events
     , ConnectionEstablishedData (..)
     , ConnectionLostData (..)
     , HandshakeCompletedData (..)
-    , Header'
+    , Header
     , HeaderReceivedData (..)
     , NetworkEvent (..)
     , PeerSharingEvent (..)
     , PeerSharingStartedData (..)
     , PeersReceivedData (..)
-    , Point'
+    , Point
     , RollBackwardData (..)
-    , Tip'
+    , Tip
     )
 import Hoard.Network.Types (Connection (..))
 
@@ -520,7 +520,7 @@ peerSharingClientImpl peer publishEvent =
 chainSyncClientImpl
     :: PeerAddress
     -> (forall event. (Typeable event) => event -> IO ())
-    -> PeerPipelined (ChainSync Header' Point' Tip') AsClient ChainSync.StIdle IO ()
+    -> PeerPipelined (ChainSync Header Point Tip) AsClient ChainSync.StIdle IO ()
 chainSyncClientImpl peer publishEvent =
     ClientPipelined $
         Effect $
@@ -533,7 +533,7 @@ chainSyncClientImpl peer publishEvent =
                     putTextLn "[DEBUG] ChainSync: Starting pipelined client, finding intersection from genesis"
                     pure findIntersect
   where
-    findIntersect :: forall c. Client (ChainSync Header' Point' Tip') (Pipelined Z c) ChainSync.StIdle IO ()
+    findIntersect :: forall c. Client (ChainSync Header Point Tip) (Pipelined Z c) ChainSync.StIdle IO ()
     findIntersect =
         Yield (ChainSync.MsgFindIntersect [genesisPoint]) $ Await $ \case
             ChainSync.MsgIntersectNotFound {} -> Effect $ do
@@ -552,7 +552,7 @@ chainSyncClientImpl peer publishEvent =
                             }
                 pure requestNext
 
-    requestNext :: forall c. Client (ChainSync Header' Point' Tip') (Pipelined Z c) ChainSync.StIdle IO ()
+    requestNext :: forall c. Client (ChainSync Header Point Tip) (Pipelined Z c) ChainSync.StIdle IO ()
     requestNext =
         Yield ChainSync.MsgRequestNext $ Await $ \case
             ChainSync.MsgRollForward hdr tip -> Effect $ do

--- a/src/Hoard/Network/Events.hs
+++ b/src/Hoard/Network/Events.hs
@@ -31,15 +31,15 @@ module Hoard.Network.Events
     , PeerSharingFailedData (..)
 
       -- * Type aliases for Cardano block types
-    , CardanoBlock'
-    , Header'
-    , Point'
-    , Tip'
+    , CardanoBlock
+    , Header
+    , Point
+    , Tip
     ) where
 
 import Data.Time (UTCTime)
-import Ouroboros.Consensus.Cardano.Block (CardanoBlock, Header, StandardCrypto)
-import Ouroboros.Network.Block (Point, Tip)
+import Ouroboros.Consensus.Cardano.Block qualified as Block
+import Ouroboros.Network.Block qualified as Block
 import Ouroboros.Network.NodeToNode (NodeToNodeVersion)
 
 import Hoard.Data.Peer (PeerAddress)
@@ -49,12 +49,12 @@ import Hoard.Data.Peer (PeerAddress)
 --
 -- These use StandardCrypto which is the standard cryptographic primitives
 -- used in the Cardano mainnet and testnets.
-type CardanoBlock' = CardanoBlock StandardCrypto
+type CardanoBlock = Block.CardanoBlock Block.StandardCrypto
 
 
-type Header' = Header CardanoBlock'
-type Point' = Point CardanoBlock'
-type Tip' = Tip CardanoBlock'
+type Header = Block.Header CardanoBlock
+type Point = Block.Point CardanoBlock
+type Tip = Block.Tip CardanoBlock
 
 
 --------------------------------------------------------------------------------
@@ -131,9 +131,9 @@ data ChainSyncStartedData = ChainSyncStartedData
 
 data HeaderReceivedData = HeaderReceivedData
     { peer :: PeerAddress
-    , header :: Header'
-    , point :: Point'
-    , tip :: Tip'
+    , header :: Header
+    , point :: Point
+    , tip :: Tip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -141,8 +141,8 @@ data HeaderReceivedData = HeaderReceivedData
 
 data RollBackwardData = RollBackwardData
     { peer :: PeerAddress
-    , point :: Point'
-    , tip :: Tip'
+    , point :: Point
+    , tip :: Tip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -150,9 +150,9 @@ data RollBackwardData = RollBackwardData
 
 data RollForwardData = RollForwardData
     { peer :: PeerAddress
-    , header :: Header'
-    , point :: Point'
-    , tip :: Tip'
+    , header :: Header
+    , point :: Point
+    , tip :: Tip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -160,8 +160,8 @@ data RollForwardData = RollForwardData
 
 data ChainSyncIntersectionFoundData = ChainSyncIntersectionFoundData
     { peer :: PeerAddress
-    , point :: Point'
-    , tip :: Tip'
+    , point :: Point
+    , tip :: Tip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -193,7 +193,7 @@ data BlockFetchStartedData = BlockFetchStartedData
 
 data BlockRequestedData = BlockRequestedData
     { peer :: PeerAddress
-    , point :: Point'
+    , point :: Point
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -201,7 +201,7 @@ data BlockRequestedData = BlockRequestedData
 
 data BlockReceivedData = BlockReceivedData
     { peer :: PeerAddress
-    , block :: CardanoBlock'
+    , block :: CardanoBlock
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -209,7 +209,7 @@ data BlockReceivedData = BlockReceivedData
 
 data BlockFetchFailedData = BlockFetchFailedData
     { peer :: PeerAddress
-    , point :: Point'
+    , point :: Point
     , errorMessage :: Text
     , timestamp :: UTCTime
     }


### PR DESCRIPTION
Remove apostrophe from chain type names to mildly simplify their usage.