### PR TITLE
chore: add CHaP to cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,12 @@
 packages: .
+tests: True
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee


### PR DESCRIPTION
Necessary to build and use some libraries from CHaP, namely test libraries in https://github.com/tweag/cardano-hoarding-node/pull/72