### PR TITLE
fix: cannot import Relude modules

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -124,6 +124,7 @@ library
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
+    , relude 
   default-language: GHC2021
 
 executable hoard-exe
@@ -203,6 +204,7 @@ executable hoard-exe
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
+    , relude 
   default-language: GHC2021
 
 executable test-connection
@@ -282,6 +284,7 @@ executable test-connection
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
+    , relude 
   default-language: GHC2021
 
 test-suite hoard-test
@@ -385,4 +388,5 @@ test-suite hoard-test
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
+    , relude 
   default-language: GHC2021

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ dependencies:
 - name: relude
   mixin:
     - (Relude as Prelude)
+    - '' # Required to make the rest of relude importable
 - aeson
 - async
 - bytestring


### PR DESCRIPTION
With the `Relude as Prelude` mixin, the rest of `relude` is inaccessible. By adding just `relude` as a mixin, we include the rest of `relude` as well, so we can import `Relude.Extra` etc.