### PR TITLE
feat: add Crypto type alias

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -43,6 +43,7 @@ library
       Hoard.Network.Types
       Hoard.Server
       Hoard.Types.Collector
+      Hoard.Types.Crypto
       Hoard.Types.DBConfig
       Hoard.Types.Environment
       Hoard.Types.Header

--- a/src/Hoard/Types/Crypto.hs
+++ b/src/Hoard/Types/Crypto.hs
@@ -1,0 +1,8 @@
+module Hoard.Types.Crypto (Crypto) where
+
+import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
+
+
+-- We use StandardCrypto which is the standard cryptographic primitives used in
+-- the Cardano mainnet and testnets.
+type Crypto = StandardCrypto


### PR DESCRIPTION
Follows the pattern used in Cardano modules, with an established "default" `Crypto` type used in the code base.