### PR TITLE
refactor: move stub Header type into HeaderReceived

### DIFF
--- a/src/Hoard/API.hs
+++ b/src/Hoard/API.hs
@@ -12,8 +12,7 @@ import Prelude hiding (appendFile, readFile)
 
 import Hoard.Effects (AppEff)
 import Hoard.Effects.Pub (publish)
-import Hoard.Events.HeaderReceived (HeaderReceived (..))
-import Hoard.Types.Header (Header)
+import Hoard.Events.HeaderReceived (Header, HeaderReceived (..))
 
 
 -- | Named routes for the API

--- a/src/Hoard/Events/HeaderReceived.hs
+++ b/src/Hoard/Events/HeaderReceived.hs
@@ -1,9 +1,10 @@
 module Hoard.Events.HeaderReceived
     ( HeaderReceived (..)
+    , Header (..)
     )
 where
 
-import Hoard.Types.Header (Header)
+import Data.Aeson (FromJSON, ToJSON)
 
 
 -- | Event emitted when a header is received
@@ -11,3 +12,10 @@ data HeaderReceived = HeaderReceived
     { header :: Header
     }
     deriving (Eq, Show, Typeable)
+
+
+data Header = Header
+    { info :: Text
+    }
+    deriving (Eq, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON)

--- a/src/Hoard/Types/Header.hs
+++ b/src/Hoard/Types/Header.hs
@@ -1,14 +1,11 @@
 module Hoard.Types.Header
-    ( Header (..)
+    ( Header
     )
 where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Ouroboros.Consensus.Cardano.Block qualified as Block
+
+import Hoard.Types.Crypto (Crypto)
 
 
--- | Simple header type for testing events
-data Header = Header
-    { info :: Text
-    }
-    deriving (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+type Header = Block.Header Crypto

--- a/test/Integration/Hoard/IntegrationSpec.hs
+++ b/test/Integration/Hoard/IntegrationSpec.hs
@@ -3,9 +3,8 @@ module Integration.Hoard.IntegrationSpec (spec_HeaderIntegration) where
 import Test.Hspec
 
 import Hoard.API (Routes (..))
-import Hoard.Events.HeaderReceived (HeaderReceived (..))
+import Hoard.Events.HeaderReceived (Header (..), HeaderReceived (..))
 import Hoard.TestHelpers (client, filterEvents, withEffectStackServer)
-import Hoard.Types.Header (Header (..))
 
 
 spec_HeaderIntegration :: Spec

--- a/test/Unit/Hoard/Listeners/HeaderReceivedListenerSpec.hs
+++ b/test/Unit/Hoard/Listeners/HeaderReceivedListenerSpec.hs
@@ -6,8 +6,7 @@ import Test.Hspec
 
 import Data.ByteString.Char8 qualified as BS
 
-import Hoard.Events.HeaderReceived (HeaderReceived (..))
-import Hoard.Types.Header (Header (..))
+import Hoard.Events.HeaderReceived (Header (..), HeaderReceived (..))
 
 
 -- | Run listener with Writer effect instead of Console


### PR DESCRIPTION
Makes way for a more proper `Header` type in the future, while not breaking our existing mock code. There is an argument to be made that we can just remove the mock code, but the tests and stuff are nice to have as reference for the time being while we get to grips with how we will structure this application.