### PR TITLE
refactor: move Cardano-based chain types to separate module

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -42,8 +42,8 @@ library
       Hoard.Network.Events
       Hoard.Network.Types
       Hoard.Server
+      Hoard.Types.Cardano
       Hoard.Types.Collector
-      Hoard.Types.Crypto
       Hoard.Types.DBConfig
       Hoard.Types.Environment
       Hoard.Types.Header

--- a/src/Hoard/Network/Events.hs
+++ b/src/Hoard/Network/Events.hs
@@ -29,32 +29,13 @@ module Hoard.Network.Events
     , PeerSharingStartedData (..)
     , PeersReceivedData (..)
     , PeerSharingFailedData (..)
-
-      -- * Type aliases for Cardano block types
-    , CardanoBlock
-    , Header
-    , Point
-    , Tip
     ) where
 
 import Data.Time (UTCTime)
-import Ouroboros.Consensus.Cardano.Block qualified as Block
-import Ouroboros.Network.Block qualified as Block
 import Ouroboros.Network.NodeToNode (NodeToNodeVersion)
 
 import Hoard.Data.Peer (PeerAddress)
-
-
--- | Type aliases for Cardano block types used throughout the network events.
---
--- These use StandardCrypto which is the standard cryptographic primitives
--- used in the Cardano mainnet and testnets.
-type CardanoBlock = Block.CardanoBlock Block.StandardCrypto
-
-
-type Header = Block.Header CardanoBlock
-type Point = Block.Point CardanoBlock
-type Tip = Block.Tip CardanoBlock
+import Hoard.Types.Cardano (CardanoBlock, CardanoHeader, CardanoPoint, CardanoTip)
 
 
 --------------------------------------------------------------------------------
@@ -131,9 +112,9 @@ data ChainSyncStartedData = ChainSyncStartedData
 
 data HeaderReceivedData = HeaderReceivedData
     { peer :: PeerAddress
-    , header :: Header
-    , point :: Point
-    , tip :: Tip
+    , header :: CardanoHeader
+    , point :: CardanoPoint
+    , tip :: CardanoTip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -141,8 +122,8 @@ data HeaderReceivedData = HeaderReceivedData
 
 data RollBackwardData = RollBackwardData
     { peer :: PeerAddress
-    , point :: Point
-    , tip :: Tip
+    , point :: CardanoPoint
+    , tip :: CardanoTip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -150,9 +131,9 @@ data RollBackwardData = RollBackwardData
 
 data RollForwardData = RollForwardData
     { peer :: PeerAddress
-    , header :: Header
-    , point :: Point
-    , tip :: Tip
+    , header :: CardanoHeader
+    , point :: CardanoPoint
+    , tip :: CardanoTip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -160,8 +141,8 @@ data RollForwardData = RollForwardData
 
 data ChainSyncIntersectionFoundData = ChainSyncIntersectionFoundData
     { peer :: PeerAddress
-    , point :: Point
-    , tip :: Tip
+    , point :: CardanoPoint
+    , tip :: CardanoTip
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -193,7 +174,7 @@ data BlockFetchStartedData = BlockFetchStartedData
 
 data BlockRequestedData = BlockRequestedData
     { peer :: PeerAddress
-    , point :: Point
+    , point :: CardanoPoint
     , timestamp :: UTCTime
     }
     deriving (Typeable)
@@ -209,7 +190,7 @@ data BlockReceivedData = BlockReceivedData
 
 data BlockFetchFailedData = BlockFetchFailedData
     { peer :: PeerAddress
-    , point :: Point
+    , point :: CardanoPoint
     , errorMessage :: Text
     , timestamp :: UTCTime
     }

--- a/src/Hoard/Types/Cardano.hs
+++ b/src/Hoard/Types/Cardano.hs
@@ -1,0 +1,31 @@
+module Hoard.Types.Cardano
+    ( Crypto
+    , CardanoBlock
+    , CardanoHeader
+    , CardanoPoint
+    , CardanoTip
+    ) where
+
+import Ouroboros.Consensus.Cardano.Block qualified as Block
+import Ouroboros.Network.Block qualified as Block
+
+
+-- We use StandardCrypto which is the standard cryptographic primitives used in
+-- the Cardano mainnet and testnets.
+type Crypto = Block.StandardCrypto
+
+
+-- | Type aliases for Cardano block types used throughout the network events.
+--
+-- These use StandardCrypto which is the standard cryptographic primitives
+-- used in the Cardano mainnet and testnets.
+type CardanoBlock = Block.CardanoBlock Crypto
+
+
+type CardanoHeader = Block.Header CardanoBlock
+
+
+type CardanoPoint = Block.Point CardanoBlock
+
+
+type CardanoTip = Block.Tip CardanoBlock

--- a/src/Hoard/Types/Crypto.hs
+++ b/src/Hoard/Types/Crypto.hs
@@ -1,8 +1,0 @@
-module Hoard.Types.Crypto (Crypto) where
-
-import Ouroboros.Consensus.Cardano.Block (StandardCrypto)
-
-
--- We use StandardCrypto which is the standard cryptographic primitives used in
--- the Cardano mainnet and testnets.
-type Crypto = StandardCrypto


### PR DESCRIPTION
Better to separate these from the Network effect for future PRs that entail serialising and deserialising these types for database purposes.