### PR TITLE
fix: use QuietSnake deriving for ConfigFile

### DIFF
--- a/src/Hoard/Config/Loader.hs
+++ b/src/Hoard/Config/Loader.hs
@@ -28,7 +28,7 @@ data ConfigFile = ConfigFile
     , protocolConfigPath :: FilePath
     }
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON)
+    deriving (FromJSON) via QuietSnake ConfigFile
 
 
 -- | Database configuration (non-sensitive connection details)


### PR DESCRIPTION
Fixes parsing error where `secretsFile` key was not found in config/dev.yaml by using `QuietSnake` deriving strategy for proper snake_case field name conversion.
```
$ cabal run hoard-exe
Loading configuration for environment: Dev
hoard-exe: user error (Failed to parse config/dev.yaml: AesonException "Error in $: parsing Hoard.Config.Loader.ConfigFile(ConfigFile) failed, key \"secretsFile\" not found")
```