### PR TITLE
fix: use correct GHC version for weeder and hlint

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -99,7 +99,7 @@ in
         echo "Building project with HIE files..."
         ${pkgs.cabal-install}/bin/cabal build --ghc-options=-fwrite-ide-info
         echo "Running weeder to detect unused code..."
-        ${pkgs.haskellPackages.weeder}/bin/weeder
+        ${pkgs.haskell-nix.tool "ghc966" "weeder" "latest"}/bin/weeder
       ''}";
     };
 
@@ -108,7 +108,10 @@ in
       type = "app";
       program = "${pkgs.writeShellScript "hlint-fix-app" ''
         echo "Running hlint --refactor on all Haskell files..."
-        find src app test -name "*.hs" -exec ${pkgs.haskellPackages.hlint}/bin/hlint --refactor {} \;
+        export PATH="${pkgs.haskell-nix.tool "ghc966" "apply-refact" "latest"}/bin:$PATH"
+        find src app test -name "*.hs" -exec ${
+          pkgs.haskell-nix.tool "ghc966" "hlint" "latest"
+        }/bin/hlint --refactor --refactor-options="-i" {} \;
         echo "Hlint refactoring complete!"
       ''}";
     };

--- a/weeder.toml
+++ b/weeder.toml
@@ -1,0 +1,22 @@
+roots = ["Main.main","^Paths_.*"]
+
+type-class-roots = false
+
+# Keep common instances that are often used implicitly
+root-instances = [
+  { class = "\\.IsString$" },
+  { class = "\\.IsList$" },
+  { class = "\\.Eq$" },
+  { class = "\\.Show$" },
+  { class = "\\.Generic$" },
+  { class = "\\.FromJSON$" },
+  { class = "\\.ToJSON$" },
+  { class = "\\.Ord$" },
+  { class = "\\.Read$" },
+  { class = "\\.DBEq$" },
+  { class = "\\.DBOrd$" },
+]
+
+unused-types = false
+
+root-modules = []


### PR DESCRIPTION
Updates `weeder` and `hlint-fix` apps to use tools built with GHC 9.6.6 (matching the project's compiler version) instead of nixpkgs defaults.

Also adds `weeder.toml` configuration to filter out common type class instances that are typically used implicitly, reducing noise in the weeder output.