### PR TITLE
refactor: run mini protocols in Eff

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -30,6 +30,7 @@ library
       Hoard.Effects.DBWrite
       Hoard.Effects.Log
       Hoard.Effects.Network
+      Hoard.Effects.Network.Codecs
       Hoard.Effects.NodeToClient
       Hoard.Effects.PeerRepo
       Hoard.Effects.Pub

--- a/src/Hoard/Effects/Network/Codecs.hs
+++ b/src/Hoard/Effects/Network/Codecs.hs
@@ -1,0 +1,22 @@
+module Hoard.Effects.Network.Codecs (hoistCodecs) where
+
+import Network.TypedProtocol.Codec (hoistCodec)
+import Ouroboros.Consensus.Network.NodeToNode (Codecs (..))
+import Prelude hiding (ByteString)
+
+
+hoistCodecs
+    :: (Functor n)
+    => (forall a. m a -> n a)
+    -> Codecs blk addr e m bCS bSCS bBF bSBF bTX bKA bPS
+    -> Codecs blk addr e n bCS bSCS bBF bSBF bTX bKA bPS
+hoistCodecs trans codecs =
+    Codecs
+        { cChainSyncCodec = hoistCodec trans codecs.cChainSyncCodec
+        , cChainSyncCodecSerialised = hoistCodec trans codecs.cChainSyncCodecSerialised
+        , cBlockFetchCodec = hoistCodec trans codecs.cBlockFetchCodec
+        , cBlockFetchCodecSerialised = hoistCodec trans codecs.cBlockFetchCodecSerialised
+        , cTxSubmission2Codec = hoistCodec trans codecs.cTxSubmission2Codec
+        , cKeepAliveCodec = hoistCodec trans codecs.cKeepAliveCodec
+        , cPeerSharingCodec = hoistCodec trans codecs.cPeerSharingCodec
+        }


### PR DESCRIPTION
Some justifications:

~~1. `Effectful.Instances` contain orphan instances to allow us to use `Eff` as a monad in Ouroboros and Cardano functions. Ouroboros and Cardano use `io-classes` type classes for `STM` behaviour, and as such we need to re-implement these for `Eff`. This is mostly just re-using the existing instances for `Eff` in the `io-classes` instances, and thus constitutes _a lot_ of boiler plate.~~
~~2. `Ouroboros.Consensus.Network.NodeToNode.defaultCodecs`, unfortunately, includes the redundant constraint `IOLike m`, which is _only_ satisfied by `IO`; only `IO` satisfies `MonadBase m IO`, one of the constraints for `IOLike` itself. But `IOLike` is not used in `defaultCodecs`, so by merely copying the implementation of `defaultCodecs` verbatim, while omitting the `IOLike` constraint, we may use `defaultCodecs` in `Eff es`.~~
~~3. Since `Ouroboros.Network.NodeToNode.connectTo` runs only in `IO`, we have to lift its invocation in `Eff`. But since we want to run the mini protocol implementations contained within in `Eff es`, we have to unlift the `versions` passed to `connectTo`. This is done using the functions defined in `Hoard.Effects.Network.Versions`, which, provided a `m a -> n a` function, attempts to merely transform a `Versions m a` to a `Versions n a`. This, unfortunately, requires unlifting the contained monadic actions in a decent number of places. An alternative approach would be unlifting `Eff es` when creating `Versions`, but transforming `Versions` instead was found to be "simpler" in this case.~~

Managed to remedy _all_ of these issues!

The plan is that all `liftIO $ putTextLn` calls will be replaced with the `Log` effect, but I'll leave that to a subsequent PR.