### PR TITLE
fix: do not test the `NodeToClient` effect yet until #86

### DIFF
--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -32,44 +32,18 @@ import Hoard.Effects.Pub (runPub)
 import Hoard.Effects.Sub (Sub, listen, runSub)
 import Hoard.Types.NodeIP (NodeIP (..))
 
-import Cardano.Api
-    ( ConsensusModeParams (CardanoModeParams)
-    , EpochSlots (EpochSlots)
-    , File (File)
-    , LocalNodeConnectInfo (..)
-    , NetworkId (Testnet)
-    , NetworkMagic (NetworkMagic)
-    )
 import Data.Default (def)
-import Effectful.Exception (tryIf)
 import Effectful.State.Static.Shared (State, evalState)
 import Hoard.Collector (dispatchDiscoveredNodes)
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.NodeToClient (immutableTip, isOnChain, runNodeToClient)
 import Hoard.Effects.Pub (Pub)
 import Hoard.Listeners.ChainSyncEventListener (chainSyncEventListener)
 import Hoard.Listeners.CollectorEventListener (collectorEventListener)
 import Hoard.Listeners.NetworkEventListener (networkEventListener)
 import Hoard.Listeners.PeerSharingEventListener (peerSharingEventListener)
 import Hoard.Types.HoardState (HoardState)
-import System.IO.Error (isDoesNotExistError)
-
-
-connectionInfo :: LocalNodeConnectInfo
-connectionInfo =
-    LocalNodeConnectInfo
-        { -- according to
-          -- https://cardano-api.cardano.intersectmbo.org/cardano-api/Cardano-Api-Network-IPC.html#g:2,
-          -- https://book.world.dev.cardano.org/environments/preprod/shelley-genesis.json,
-          -- https://book.world.dev.cardano.org/environments/mainnet/shelley-genesis.json,
-          -- https://github.com/IntersectMBO/cardano-node/blob/master/configuration/cardano/mainnet-shelley-genesis.json#L62,
-          -- and https://github.com/IntersectMBO/cardano-node/blob/master/nix/workbench/profile/presets/mainnet/genesis/genesis-shelley.json#L62
-          localConsensusModeParams = CardanoModeParams $ EpochSlots $ 432000
-        , localNodeNetworkId = Testnet $ NetworkMagic $ 1
-        , localNodeSocketPath = File "preprod.socket"
-        }
 
 
 main :: IO ()
@@ -150,18 +124,18 @@ testConnection = do
     Conc.fork_ $ listen collectorEventListener
     Conc.fork_ $ listen dispatchDiscoveredNodes
 
-    -- query immutable tip
-    (=<<) (either (Log.warn . toText . displayException) pure)
-        . tryIf isDoesNotExistError
-        . runNodeToClient connectionInfo
-        $ do
-            tip0 <- immutableTip
-            Log.debug (show tip0)
-            Log.debug =<< show <$> isOnChain tip0
-            liftIO $ threadDelay (5 * 1000000)
-            tip1 <- immutableTip
-            Log.debug (show tip1)
-            Log.debug =<< show <$> isOnChain tip1
+    -- -- query immutable tip
+    -- (=<<) (either (Log.warn . toText . displayException) pure)
+    --     . tryIf isDoesNotExistError
+    --     . runNodeToClient connectionInfo
+    --     $ do
+    --         tip0 <- immutableTip
+    --         Log.debug (show tip0)
+    --         Log.debug =<< show <$> isOnChain tip0
+    --         liftIO $ threadDelay (5 * 1000000)
+    --         tip1 <- immutableTip
+    --         Log.debug (show tip1)
+    --         Log.debug =<< show <$> isOnChain tip1
 
     -- Connect to peer
     conn <- connectToPeer previewRelay.address


### PR DESCRIPTION
fix: do not test the `NodeToClient` effect yet until #86

[`tryIf p . runNodeToClient c`](https://github.com/tweag/cardano-hoarding-node/pull/101/files#diff-7fdee8ab21a97d868dd477e1634689c9e56335c7dcd8060b139a13063cc9a4e8L155) is not working anymore because `ki`, rightfully, does not support catching exceptions inside of `scoped` properly.