### PR TITLE
feat: wire logging config into effect stack

### DIFF
--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -109,7 +109,7 @@ runEffectStack :: (MonadIO m) => Config -> Eff AppEffects a -> m a
 runEffectStack config action = liftIO $ do
     result <-
         runEff
-            . runLog
+            . runLog config.logging
             . runClock
             . runFileSystem
             . runConcurrent
@@ -135,7 +135,7 @@ runEffectStackReturningState :: (MonadIO m) => Config -> Eff AppEffects a -> m (
 runEffectStackReturningState config action = liftIO $ do
     result <-
         runEff
-            . runLog
+            . runLog config.logging
             . runClock
             . runFileSystem
             . runConcurrent

--- a/src/Hoard/Effects/Log.hs
+++ b/src/Hoard/Effects/Log.hs
@@ -13,7 +13,6 @@ module Hoard.Effects.Log
     , Config (..)
     , Severity (..)
     , defaultConfig
-    , runLogWith
     ) where
 
 import Effectful (Eff, Effect, IOE, (:>))
@@ -57,12 +56,6 @@ err :: (Log :> es) => Text -> Eff es ()
 err = log ERROR
 
 
-runLog :: (IOE :> es) => Eff (Log : es) a -> Eff es a
-runLog = interpret_ $ \(Log severity msg) -> liftIO $ do
-    T.hPutStrLn stdout $ "[" <> (show severity) <> "] " <> msg
-    hFlush stdout
-
-
 -- | Consumes `Log` effects, and discards the logged messages
 runLogNoOp :: Eff (Log : es) a -> Eff es a
 runLogNoOp = interpret_ $ \(Log _ _) -> pure ()
@@ -82,8 +75,8 @@ defaultConfig =
         }
 
 
-runLogWith :: (IOE :> es) => Config -> Eff (Log : es) a -> Eff es a
-runLogWith config = interpret_ $ \(Log severity msg) -> liftIO $
+runLog :: (IOE :> es) => Config -> Eff (Log : es) a -> Eff es a
+runLog config = interpret_ $ \(Log severity msg) -> liftIO $
     when (severity >= config.minimumSeverity) $ do
         T.hPutStrLn config.output $ "[" <> (show severity) <> "] " <> msg
         hFlush stdout

--- a/src/Hoard/Effects/Network.hs
+++ b/src/Hoard/Effects/Network.hs
@@ -67,7 +67,6 @@ import Ouroboros.Network.Snocket (socketSnocket)
 
 import Data.ByteString.Lazy qualified as LBS
 import Data.Map.Strict qualified as Map
-import Debug.Trace qualified
 import Network.TypedProtocol.Peer.Client qualified as Peer
 import Ouroboros.Network.Protocol.ChainSync.Type qualified as ChainSync
 import Ouroboros.Network.Protocol.PeerSharing.Client qualified as PeerSharing
@@ -494,9 +493,7 @@ peerSharingClientImpl
     => (forall x. Eff es x -> IO x)
     -> PeerAddress
     -> PeerSharingClient SockAddr IO ()
-peerSharingClientImpl unlift peer =
-    Debug.Trace.trace "[DEBUG] PeerSharing: Creating SendMsgShareRequest..." $
-        requestPeers withPeers
+peerSharingClientImpl unlift peer = requestPeers withPeers
   where
     requestPeers = PeerSharing.SendMsgShareRequest $ PeerSharingAmount 100
     withPeers peerAddrs = unlift do

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -103,7 +103,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
     wireTapThreadID <- forkIO $ recordMessages wireTapOutput wireTap
     (a, finalState) <-
         runEff
-            . runLog
+            . runLog config.logging
             . runFileSystem
             . runConcurrent
             . runSub config.inChan

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -11,7 +11,7 @@ import Hasql.Transaction qualified as TX
 
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite, runTransaction)
-import Hoard.Effects.Log (runLog)
+import Hoard.Effects.Log qualified as Log
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.DBConfig (DBPools (..))
 
@@ -35,7 +35,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First write some data
             _ <-
                 runEff
-                    . runLog
+                    . Log.runLog Log.defaultConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert-test"
@@ -57,7 +57,7 @@ spec_DBEffects = withCleanTestDatabase $ do
         it "can write to the database" $ \config -> do
             result <-
                 runEff
-                    . runLog
+                    . Log.runLog Log.defaultConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert-test"
@@ -70,7 +70,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First insert
             _ <-
                 runEff
-                    . runLog
+                    . Log.runLog Log.defaultConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert"
@@ -79,7 +79,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- Then delete
             result <-
                 runEff
-                    . runLog
+                    . Log.runLog Log.defaultConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "delete"

--- a/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
@@ -14,7 +14,7 @@ import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite)
-import Hoard.Effects.Log (runLog)
+import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo (getPeerByAddress, runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.DBConfig (DBPools (..))
@@ -25,7 +25,7 @@ spec_PeerPersistence :: Spec
 spec_PeerPersistence = do
     let runWrite config action =
             runEff
-                . runLog
+                . Log.runLog Log.defaultConfig
                 . runErrorNoCallStack @Text
                 . runDBRead config.pools.readerPool
                 . runDBWrite config.pools.writerPool


### PR DESCRIPTION
- Replace `runLogWith` with `runLog` as the primary interpreter
- Pass `config.logging` to `runLog` in both effect stack runners
- Update` test-connection `to use `loadConfig` for env var support
- Update all test files to use `Log.runLog Log.defaultConfig`

Logging now respects configuration from config files and environment variables (LOG, LOGGING, DEBUG) throughout the application.