### PR TITLE
feat: add block fetch implementation

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -29,10 +29,12 @@ library
       Hoard.Effects.Conc
       Hoard.Effects.DBRead
       Hoard.Effects.DBWrite
+      Hoard.Effects.Input
       Hoard.Effects.Log
       Hoard.Effects.Network
       Hoard.Effects.Network.Codecs
       Hoard.Effects.NodeToClient
+      Hoard.Effects.Output
       Hoard.Effects.PeerRepo
       Hoard.Effects.Pub
       Hoard.Effects.Sub

--- a/src/Hoard/Effects/Input.hs
+++ b/src/Hoard/Effects/Input.hs
@@ -1,0 +1,52 @@
+module Hoard.Effects.Input
+    ( Input (..)
+    , input
+    , runInputEff
+    , runInputConst
+    , runInputChan
+    , runInputList
+    ) where
+
+import Control.Concurrent.Chan.Unagi (OutChan, readChan)
+import Effectful (Eff, Effect, IOE, inject, (:>))
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.State.Static.Shared (evalState, state)
+import Effectful.TH (makeEffect)
+import Prelude hiding (evalState, modify, state)
+
+
+-- | Receive something from an arbitrary place where the origin of the
+-- something in question is not of concern to the logic utilizing it.
+data Input a :: Effect where
+    Input :: Input a m a
+
+
+makeEffect ''Input
+
+
+-- | Run an Input effect by evaluating an `Eff` value.
+runInputEff :: (Eff es a) -> Eff (Input a : es) b -> Eff es b
+runInputEff eff = interpret_ $ \Input -> eff
+
+
+-- | Run an Input effect by providing a constant value.
+runInputConst :: a -> Eff (Input a : es) b -> Eff es b
+runInputConst = runInputEff . pure
+
+
+-- | Run an Input effect by reading from an `OutChan`.
+runInputChan :: (IOE :> es) => OutChan a -> Eff (Input a : es) b -> Eff es b
+runInputChan = runInputEff . liftIO . readChan
+
+
+-- | Run an Input effect with the items provided by a NonEmpty list. Loops
+-- through the list again once it reaches the end.
+runInputList :: NonEmpty a -> Eff (Input a : es) b -> Eff es b
+runInputList items =
+    evalState items
+        . runInputEff
+            ( state $ \case
+                x :| [] -> (x, items)
+                x :| (y : ys) -> (x, y :| ys)
+            )
+        . inject

--- a/src/Hoard/Effects/Output.hs
+++ b/src/Hoard/Effects/Output.hs
@@ -1,0 +1,58 @@
+module Hoard.Effects.Output
+    ( Output (..)
+    , output
+    , runOutputEff
+    , runOutputDiscard
+    , runOutputChan
+    , runOutputAsPub
+    , runOutputList
+    )
+where
+
+import Prelude hiding (modify, runState)
+
+import Control.Concurrent.Chan.Unagi (InChan, writeChan)
+import Data.Dynamic qualified as Dyn
+import Effectful (Eff, Effect, IOE, (:>))
+import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
+import Effectful.State.Static.Local (modify, runState)
+import Effectful.TH (makeEffect)
+import Hoard.Effects.Pub (Pub, publish)
+
+
+-- | Output something to whomever cares in a manner that is of no concern for
+-- the logic producing the outputted value.
+data Output a :: Effect where
+    Output :: a -> Output a m ()
+
+
+makeEffect ''Output
+
+
+-- | Run an Output effect by discarding all outputted values.
+runOutputDiscard :: Eff (Output a : es) x -> Eff es x
+runOutputDiscard = interpret_ $ \(Output _) -> pure ()
+
+
+-- | Run an Output effect using a given Eff-producing function.
+runOutputEff :: (a -> Eff es ()) -> Eff (Output a : es) x -> Eff es x
+runOutputEff eff = interpret_ $ \(Output x) -> eff x
+
+
+-- | Run an Output effect by writing to an `InChan`.
+runOutputChan :: (IOE :> es) => InChan a -> Eff (Output a : es) x -> Eff es x
+runOutputChan inChan = runOutputEff $ liftIO . writeChan inChan
+
+
+-- | Run an Output by publishing values with the `Pub` effect.
+runOutputAsPub :: (Typeable a, Pub :> es) => Eff (Output a : es) x -> Eff es x
+runOutputAsPub = runOutputEff $ publish . Dyn.toDyn
+
+
+-- | Collect all values from an Output effect into a list.
+runOutputList :: Eff (Output a : es) x -> Eff es (x, [a])
+runOutputList =
+    fmap (second reverse)
+        . reinterpret_
+            (runState [])
+            (\(Output x) -> modify (x :))

--- a/src/Hoard/Network/Events.hs
+++ b/src/Hoard/Network/Events.hs
@@ -19,9 +19,9 @@ module Hoard.Network.Events
     , RollBackwardData (..)
     , RollForwardData (..)
     , ChainSyncIntersectionFoundData (..)
+    , BlockFetchRequest (..)
     , BlockFetchEvent (..)
     , BlockFetchStartedData (..)
-    , BlockRequestedData (..)
     , BlockReceivedData (..)
     , BlockFetchFailedData (..)
     , BlockBatchCompletedData (..)
@@ -158,7 +158,6 @@ data ChainSyncIntersectionFoundData = ChainSyncIntersectionFoundData
 -- has provided the headers.
 data BlockFetchEvent
     = BlockFetchStarted BlockFetchStartedData
-    | BlockRequested BlockRequestedData
     | BlockReceived BlockReceivedData
     | BlockFetchFailed BlockFetchFailedData
     | BlockBatchCompleted BlockBatchCompletedData
@@ -172,7 +171,8 @@ data BlockFetchStartedData = BlockFetchStartedData
     deriving (Show, Typeable)
 
 
-data BlockRequestedData = BlockRequestedData
+-- | A request to fetch a single block.
+data BlockFetchRequest = BlockFetchRequest
     { peer :: PeerAddress
     , point :: CardanoPoint
     , timestamp :: UTCTime


### PR DESCRIPTION
Initial implementation of block fetch mini protocol. Currently, this waits for requests to download blocks over the `Input BlockFetchRequest` effect, which produces no `BlockFetchRequest`s for the block fetch mini protocol just yet. Following PRs will focus on combining chain sync and block fetch, to convert `HeadersReceived` from chain sync into a `BlockFetchRequest` for block fetch, as well as storing these blocks and headers in the database in a sensible manner.