### PR TITLE
fix: correct YAML paths in postgres.nix

### DIFF
--- a/nix/postgres.nix
+++ b/nix/postgres.nix
@@ -18,9 +18,9 @@
       fi
 
       # Parse config values from YAML
-      DB_HOST=$(${pkgs.yq-go}/bin/yq '.database.reader.host' "$CONFIG_FILE")
-      DB_PORT=$(${pkgs.yq-go}/bin/yq '.database.reader.port' "$CONFIG_FILE")
-      DB_NAME=$(${pkgs.yq-go}/bin/yq '.database.reader.database_name' "$CONFIG_FILE")
+      DB_HOST=$(${pkgs.yq-go}/bin/yq '.database.host' "$CONFIG_FILE")
+      DB_PORT=$(${pkgs.yq-go}/bin/yq '.database.port' "$CONFIG_FILE")
+      DB_NAME=$(${pkgs.yq-go}/bin/yq '.database.database_name' "$CONFIG_FILE")
 
       echo "Loading configuration from: $CONFIG_FILE"
       echo "  Database: $DB_NAME"


### PR DESCRIPTION
Fixed incorrect YAML paths that were reading from
.database.reader.* instead of .database.*. The reader-specific paths are for user credentials in secrets file, not for the main database connection configuration.