### PR TITLE
refactor: abstract channel operations into Chan effect

### DIFF
--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -32,6 +32,7 @@ import Hoard.Config.Loader (loadConfig)
 import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects (Config (..))
+import Hoard.Effects.Chan (runChan)
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.Conc (Conc, scoped)
 import Hoard.Effects.Conc qualified as Conc
@@ -84,6 +85,7 @@ main = withIOManager $ \ioManager -> do
         $ \scope -> do
             Conc.runConcWithKi scope
                 . runErrorNoCallStack @Text
+                . runChan
                 . runSub config.inChan
                 . runPub config.inChan
                 . runNetwork config.ioManager config.protocolConfigPath

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -25,6 +25,7 @@ library
       Hoard.DB.Schema
       Hoard.DB.Schemas.Peers
       Hoard.Effects
+      Hoard.Effects.Chan
       Hoard.Effects.Clock
       Hoard.Effects.Conc
       Hoard.Effects.DBRead

--- a/src/Hoard/Effects/Chan.hs
+++ b/src/Hoard/Effects/Chan.hs
@@ -1,0 +1,59 @@
+-- | Module: Hoard.Effects.Chan
+-- Description: Effect for creating and operating on bidirectional channels
+module Hoard.Effects.Chan
+    ( -- * Effect
+      Chan
+    , newChan
+    , readChan
+    , writeChan
+    , dupChan
+    , runChan
+
+      -- * Channel Types
+
+      -- | Re-exported from the underlying channel implementation.
+      -- Import these from this module rather than directly from Unagi
+      -- to maintain abstraction boundaries.
+    , InChan
+    , OutChan
+    ) where
+
+import Control.Concurrent.Chan.Unagi (InChan, OutChan)
+import Control.Concurrent.Chan.Unagi qualified as Unagi
+import Effectful (Eff, Effect, IOE, (:>))
+import Effectful.Dispatch.Dynamic (interpret)
+import Effectful.TH (makeEffect)
+
+
+-- | Effect for creating and operating on bidirectional channels.
+data Chan :: Effect where
+    NewChan :: Chan m (Unagi.InChan a, Unagi.OutChan a)
+    ReadChan :: Unagi.OutChan a -> Chan m a
+    WriteChan :: Unagi.InChan a -> a -> Chan m ()
+    DupChan :: Unagi.InChan a -> Chan m (Unagi.OutChan a)
+
+
+makeEffect ''Chan
+
+
+-- | Run the Chan effect using real Unagi channels.
+--
+-- This is an interpreter that performs actual channel operations via IO.
+--
+-- = Usage
+--
+-- @
+-- runChan $ do
+--     (inChan, outChan) <- newChan
+--     outChan2 <- dupChan inChan  -- Create another reader
+--     writeChan inChan value
+--     value1 <- readChan outChan
+--     value2 <- readChan outChan2  -- Both readers get the same value
+--     ...
+-- @
+runChan :: (IOE :> es) => Eff (Chan : es) a -> Eff es a
+runChan = interpret $ \_ -> \case
+    NewChan -> liftIO Unagi.newChan
+    ReadChan outChan -> liftIO $ Unagi.readChan outChan
+    WriteChan inChan val -> liftIO $ Unagi.writeChan inChan val
+    DupChan inChan -> liftIO $ Unagi.dupChan inChan

--- a/src/Hoard/Effects/Input.hs
+++ b/src/Hoard/Effects/Input.hs
@@ -7,11 +7,12 @@ module Hoard.Effects.Input
     , runInputList
     ) where
 
-import Control.Concurrent.Chan.Unagi (OutChan, readChan)
-import Effectful (Eff, Effect, IOE, inject, (:>))
+import Effectful (Eff, Effect, inject, (:>))
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.State.Static.Shared (evalState, state)
 import Effectful.TH (makeEffect)
+import Hoard.Effects.Chan (Chan, OutChan)
+import Hoard.Effects.Chan qualified as Chan
 import Prelude hiding (evalState, modify, state)
 
 
@@ -35,8 +36,8 @@ runInputConst = runInputEff . pure
 
 
 -- | Run an Input effect by reading from an `OutChan`.
-runInputChan :: (IOE :> es) => OutChan a -> Eff (Input a : es) b -> Eff es b
-runInputChan = runInputEff . liftIO . readChan
+runInputChan :: (Chan :> es) => OutChan a -> Eff (Input a : es) b -> Eff es b
+runInputChan = runInputEff . Chan.readChan
 
 
 -- | Run an Input effect with the items provided by a NonEmpty list. Loops

--- a/src/Hoard/Effects/Output.hs
+++ b/src/Hoard/Effects/Output.hs
@@ -11,12 +11,13 @@ where
 
 import Prelude hiding (modify, runState)
 
-import Control.Concurrent.Chan.Unagi (InChan, writeChan)
 import Data.Dynamic qualified as Dyn
-import Effectful (Eff, Effect, IOE, (:>))
+import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
 import Effectful.State.Static.Local (modify, runState)
 import Effectful.TH (makeEffect)
+import Hoard.Effects.Chan (Chan, InChan)
+import Hoard.Effects.Chan qualified as Chan
 import Hoard.Effects.Pub (Pub, publish)
 
 
@@ -40,8 +41,8 @@ runOutputEff eff = interpret_ $ \(Output x) -> eff x
 
 
 -- | Run an Output effect by writing to an `InChan`.
-runOutputChan :: (IOE :> es) => InChan a -> Eff (Output a : es) x -> Eff es x
-runOutputChan inChan = runOutputEff $ liftIO . writeChan inChan
+runOutputChan :: (Chan :> es) => InChan a -> Eff (Output a : es) x -> Eff es x
+runOutputChan inChan = runOutputEff $ Chan.writeChan inChan
 
 
 -- | Run an Output by publishing values with the `Pub` effect.

--- a/src/Hoard/Effects/Sub.hs
+++ b/src/Hoard/Effects/Sub.hs
@@ -5,11 +5,11 @@ module Hoard.Effects.Sub
     )
 where
 
-import Control.Concurrent.Chan.Unagi (InChan, dupChan, readChan)
-import Effectful (Dispatch (..), DispatchOf, Eff, Effect, IOE, (:>))
-import Effectful.Dispatch.Dynamic (interpret, localSeqUnlift, send)
-
 import Data.Dynamic qualified as Dyn
+import Effectful (Dispatch (..), DispatchOf, Eff, Effect, (:>))
+import Effectful.Dispatch.Dynamic (interpret, localSeqUnlift, send)
+import Hoard.Effects.Chan (Chan, InChan)
+import Hoard.Effects.Chan qualified as Chan
 
 
 data Sub :: Effect where
@@ -23,12 +23,12 @@ listen :: (Sub :> es, Typeable a) => (a -> Eff es ()) -> Eff es Void
 listen = send . Listen
 
 
-runSub :: (IOE :> es) => InChan Dyn.Dynamic -> Eff (Sub : es) a -> Eff es a
+runSub :: (Chan :> es) => InChan Dyn.Dynamic -> Eff (Sub : es) a -> Eff es a
 runSub inChan = interpret $ \env -> \case
     Listen listener -> localSeqUnlift env $ \unlift -> do
-        chan <- liftIO $ dupChan inChan
+        chan <- Chan.dupChan inChan
         forever $ do
-            event <- liftIO $ readChan chan
+            event <- Chan.readChan chan
             case Dyn.fromDynamic event of
                 Nothing -> pure ()
                 Just x -> unlift $ listener x

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -10,7 +10,7 @@ where
 import Prelude hiding (State, atomicModifyIORef', newIORef, readIORef, runState)
 
 import Control.Concurrent (forkIO, killThread)
-import Control.Concurrent.Chan.Unagi (OutChan, dupChan, newChan, readChan)
+import Control.Concurrent.Chan.Unagi (dupChan, newChan, readChan)
 import Data.Default (def)
 import Data.Dynamic (Dynamic, fromDynamic)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
@@ -27,6 +27,7 @@ import Effectful
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.State.Static.Shared (State, runState)
+import Hoard.Effects.Chan (Chan, OutChan, runChan)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp (testWithApplication)
@@ -107,6 +108,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
             . runLog config.logging
             . runFileSystem
             . runConcurrent
+            . runChan
             . runSub config.inChan
             . runPub config.inChan
             . runState def
@@ -126,6 +128,7 @@ type TestAppEffs =
     [ State HoardState
     , Pub
     , Sub
+    , Chan
     , Concurrent
     , FileSystem
     , Log


### PR DESCRIPTION
Introduces a new Chan effect that encapsulates all Unagi channel operations (newChan, readChan, writeChan, dupChan), eliminating direct IOE dependencies from Input, Output, Pub, and Sub effect interpreters.


Changes:
- Add Chan effect with full channel operation support
- Update Input/Output/Pub/Sub interpreters to use Chan
- Refactor `withBridge` to use Chan instead of direct IO
- Reorder effect stacks to satisfy Chan dependencies
- Update test helpers and app runners