### PR TITLE
chore: restrict cuddle to <1.1.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,3 +10,5 @@ repository cardano-haskell-packages
     bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+constraints:
+  cuddle <1.1.0.0


### PR DESCRIPTION
[1.1.0.0 introduces a breaking change][breaking] that [`cardano-ledger-binary:testlib` does not adequately take into consideration][dep]. See

[breaking]: https://github.com/input-output-hk/cuddle/blob/master/CHANGELOG.md#1100
[dep]: https://github.com/IntersectMBO/cardano-ledger/blob/d32192fc68cfbe63ec4ffcb786b77e2c8e96b8d5/libs/cardano-ledger-binary/cardano-ledger-binary.cabal#L127