### PR TITLE
refactor: rename Network effect to NodeToNode

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,6 +9,6 @@
       - docs
 
 # Ignore "Avoid lambda" in Network effects module (needed for type polymorphism)
-- ignore: {name: Avoid lambda, within: Hoard.Effects.Network}
+- ignore: {name: Avoid lambda, within: Hoard.Effects.NodeToNode}
 
 - group: {name: future, enabled: true}

--- a/app/test-connection/Main.hs
+++ b/app/test-connection/Main.hs
@@ -43,8 +43,8 @@ import Hoard.Effects.DBWrite (runDBWrite)
 import Hoard.Effects.HeaderRepo (HeaderRepo, runHeaderRepo)
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.Network (Network, connectToPeer, isConnected, runNetwork)
 import Hoard.Effects.NodeToClient (immutableTip, isOnChain, runNodeToClient)
+import Hoard.Effects.NodeToNode (NodeToNode, connectToPeer, isConnected, runNodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, runPeerRepo, upsertPeers)
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, listen, runSub)
@@ -95,7 +95,7 @@ main = withIOManager $ \ioManager -> do
                 . runChan
                 . runSub config.inChan
                 . runPub config.inChan
-                . runNetwork config.ioManager config.protocolConfigPath
+                . runNodeToNode config.ioManager config.protocolConfigPath
                 . runDBRead config.dbPools.readerPool
                 . runDBWrite config.dbPools.writerPool
                 . runPeerRepo
@@ -134,7 +134,7 @@ testConnection
     :: ( Conc :> es
        , IOE :> es
        , Log :> es
-       , Network :> es
+       , NodeToNode :> es
        , Sub :> es
        , Pub :> es
        , State HoardState :> es

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -37,9 +37,9 @@ library
       Hoard.Effects.HeaderRepo
       Hoard.Effects.Input
       Hoard.Effects.Log
-      Hoard.Effects.Network
-      Hoard.Effects.Network.Codecs
       Hoard.Effects.NodeToClient
+      Hoard.Effects.NodeToNode
+      Hoard.Effects.NodeToNode.Codecs
       Hoard.Effects.Output
       Hoard.Effects.PeerRepo
       Hoard.Effects.Pub

--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -14,7 +14,7 @@ import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.Network (Network, connectToPeer)
+import Hoard.Effects.NodeToNode (NodeToNode, connectToPeer)
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Effects.Pub (Pub, publish)
 import Hoard.Events.Collector (CollectorEvent (..))
@@ -27,7 +27,7 @@ dispatchDiscoveredNodes
     :: ( Conc :> es
        , IOE :> es
        , Log :> es
-       , Network :> es
+       , NodeToNode :> es
        , PeerRepo :> es
        , Pub :> es
        , State HoardState :> es
@@ -64,7 +64,7 @@ dispatchDiscoveredNodes = \case
 
 
 runCollector
-    :: (IOE :> es, Network :> es, Pub :> es)
+    :: (IOE :> es, NodeToNode :> es, Pub :> es)
     => Peer
     -> Eff es Void
 runCollector peer = do

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -35,8 +35,8 @@ import Hoard.Effects.DBWrite (DBWrite, runDBWrite)
 import Hoard.Effects.HeaderRepo (HeaderRepo, runHeaderRepo)
 import Hoard.Effects.Log (Log, runLog)
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.Network (Network, runNetwork)
 import Hoard.Effects.NodeToClient (NodeToClient, runNodeToClient)
+import Hoard.Effects.NodeToNode (NodeToNode, runNodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, runPeerRepo)
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, runSub)
@@ -77,7 +77,7 @@ type AppEff es =
     , Sub :> es
     , Pub :> es
     , Chan :> es
-    , Network :> es
+    , NodeToNode :> es
     , DBRead :> es
     , DBWrite :> es
     , PeerRepo :> es
@@ -98,7 +98,7 @@ type AppEffects =
      , HeaderRepo
      , DBWrite
      , DBRead
-     , Network
+     , NodeToNode
      , Error Text
      , Pub
      , Sub
@@ -130,7 +130,7 @@ runEffectStack config action = liftIO $ do
                     . runSub config.inChan
                     . runPub config.inChan
                     . runErrorNoCallStack @Text
-                    . runNetwork config.ioManager config.protocolConfigPath
+                    . runNodeToNode config.ioManager config.protocolConfigPath
                     . runDBRead config.dbPools.readerPool
                     . runDBWrite config.dbPools.writerPool
                     . runHeaderRepo
@@ -159,7 +159,7 @@ runEffectStackReturningState config action = liftIO $ do
                     . runSub config.inChan
                     . runPub config.inChan
                     . runErrorNoCallStack @Text
-                    . runNetwork config.ioManager config.protocolConfigPath
+                    . runNodeToNode config.ioManager config.protocolConfigPath
                     . runDBRead config.dbPools.readerPool
                     . runDBWrite config.dbPools.writerPool
                     . runHeaderRepo

--- a/src/Hoard/Effects/NodeToClient.hs
+++ b/src/Hoard/Effects/NodeToClient.hs
@@ -52,7 +52,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Client qualified as Q
 import Hoard.Control.Exception (withExceptionLogging)
 import Hoard.Effects.Conc (Conc, fork_)
 import Hoard.Effects.Log (Log)
-import Hoard.Effects.Network (loadNodeConfig)
+import Hoard.Effects.NodeToNode (loadNodeConfig)
 
 
 data NodeToClient :: Effect where

--- a/src/Hoard/Effects/NodeToNode/Codecs.hs
+++ b/src/Hoard/Effects/NodeToNode/Codecs.hs
@@ -1,4 +1,4 @@
-module Hoard.Effects.Network.Codecs (hoistCodecs) where
+module Hoard.Effects.NodeToNode.Codecs (hoistCodecs) where
 
 import Network.TypedProtocol.Codec (hoistCodec)
 import Ouroboros.Consensus.Network.NodeToNode (Codecs (..))


### PR DESCRIPTION
Rename the Network effect and module to NodeToNode to better reflect its purpose and distinguish it from NodeToClient. This improves code clarity by making the distinction between node-to-node and node-to-client protocols more explicit throughout the codebase, especially since I'm about to introduce another protocol effect for tracing.

Changes:
- Renamed Hoard.Effects.Network to Hoard.Effects.NodeToNode
- Renamed Hoard.Effects.Network.Codecs to Hoard.Effects.NodeToNode.Codecs
- Updated all imports and references across the codebase
- Updated HLint configuration to reflect new module name