### PR TITLE
fix: `generateMaterialized` instructions

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -32,7 +32,7 @@ let
       if ! nix eval --no-warn-dirty .#checks.${system}.git-hooks --apply 'x: "ok"' 2>/dev/null >/dev/null; then
         echo "⚠️  WARNING: haskell.nix materialization may be out of date!"
         echo "If you changed dependencies or flake inputs, please run:"
-        echo "  nix build --no-link 2>&1 | grep generateMaterialized | sh"
+        echo "  nix build --no-link 2>&1 | grep -o '/[/[:alnum:]]\+-generateMaterialized [/_[:alnum:]]\+$' | sh"
         echo ""
         echo "Press Enter to continue anyway, or Ctrl-C to abort and regenerate."
         read -r


### PR DESCRIPTION
use `grep -o` to pass `/nix/store/a3zxg-generateMaterialized nix/materialized` to `sh` instead of the following as before.
```
       > Materialized nix used for haskell-project-plan-to-nix-pkgs incorrect. To fix check you are in the right directory and run: /nix/store/a3zxg-generateMaterialized nix/materialized
```

this had been causing to the following error.
```
$ nix build --no-link 2>&1 | grep generateMaterialized | sh
error: 'used' is not a recognised command
Try 'nix --help' for more information.
```