### PR TITLE
refactor: demote NodeToNode effect to a mere function

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -27,6 +27,7 @@ library
       Hoard.Data.Header.Extract
       Hoard.Data.ID
       Hoard.Data.Peer
+      Hoard.Data.ProtocolInfo
       Hoard.DB.Schema
       Hoard.DB.Schemas.Blocks
       Hoard.DB.Schemas.HeaderReceipts

--- a/src/Hoard/Data/ProtocolInfo.hs
+++ b/src/Hoard/Data/ProtocolInfo.hs
@@ -1,0 +1,51 @@
+module Hoard.Data.ProtocolInfo
+    ( CardanoProtocolInfo
+    , ProtocolConfigPath (..)
+    , loadProtocolInfo
+    , loadNodeConfig
+    ) where
+
+import Cardano.Api
+    ( File (..)
+    , NodeConfig
+    , mkProtocolInfoCardano
+    , readCardanoGenesisConfig
+    , readNodeConfig
+    )
+import Effectful (Eff, IOE, (:>))
+import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+
+import Hoard.Types.Cardano (CardanoBlock)
+
+
+type CardanoProtocolInfo = ProtocolInfo CardanoBlock
+
+
+newtype ProtocolConfigPath = ProtocolConfigPath {getProtocolConfigPath :: FilePath}
+
+
+loadNodeConfig :: (IOE :> es) => FilePath -> Eff es NodeConfig
+loadNodeConfig configPath = do
+    let configFile = File configPath
+    nodeConfigResult <- runExceptT $ readNodeConfig configFile
+    case nodeConfigResult of
+        Left err -> error $ "Failed to read node config: " <> err
+        Right cfg -> pure cfg
+
+
+-- | Load the Cardano protocol info from config files.
+-- This is needed to get the CodecConfig for creating proper codecs.
+loadProtocolInfo :: (IOE :> es) => ProtocolConfigPath -> Eff es (ProtocolInfo CardanoBlock)
+loadProtocolInfo (ProtocolConfigPath configPath) = do
+    -- Load NodeConfig
+    nodeConfig <- loadNodeConfig configPath
+
+    -- Load GenesisConfig
+    genesisConfigResult <- runExceptT $ readCardanoGenesisConfig nodeConfig
+    genesisConfig <- case genesisConfigResult of
+        Left err -> error $ "Failed to read genesis config: " <> show err
+        Right cfg -> pure cfg
+
+    -- Create ProtocolInfo
+    let (protocolInfo, _mkBlockForging) = mkProtocolInfoCardano genesisConfig
+    pure protocolInfo

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -36,7 +36,6 @@ import Hoard.Effects.HeaderRepo (HeaderRepo, runHeaderRepo)
 import Hoard.Effects.Log (Log, runLog)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.NodeToClient (NodeToClient, runNodeToClient)
-import Hoard.Effects.NodeToNode (NodeToNode, runNodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, runPeerRepo)
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, runSub)
@@ -77,7 +76,6 @@ type AppEff es =
     , Sub :> es
     , Pub :> es
     , Chan :> es
-    , NodeToNode :> es
     , DBRead :> es
     , DBWrite :> es
     , PeerRepo :> es
@@ -98,7 +96,6 @@ type AppEffects =
      , HeaderRepo
      , DBWrite
      , DBRead
-     , NodeToNode
      , Error Text
      , Pub
      , Sub
@@ -130,7 +127,6 @@ runEffectStack config action = liftIO $ do
                     . runSub config.inChan
                     . runPub config.inChan
                     . runErrorNoCallStack @Text
-                    . runNodeToNode config.ioManager config.protocolConfigPath
                     . runDBRead config.dbPools.readerPool
                     . runDBWrite config.dbPools.writerPool
                     . runHeaderRepo
@@ -159,7 +155,6 @@ runEffectStackReturningState config action = liftIO $ do
                     . runSub config.inChan
                     . runPub config.inChan
                     . runErrorNoCallStack @Text
-                    . runNodeToNode config.ioManager config.protocolConfigPath
                     . runDBRead config.dbPools.readerPool
                     . runDBWrite config.dbPools.writerPool
                     . runHeaderRepo

--- a/src/Hoard/Effects/NodeToClient.hs
+++ b/src/Hoard/Effects/NodeToClient.hs
@@ -50,9 +50,9 @@ import Ouroboros.Network.Protocol.ChainSync.Client qualified as S
 import Ouroboros.Network.Protocol.LocalStateQuery.Client qualified as Q
 
 import Hoard.Control.Exception (withExceptionLogging)
+import Hoard.Data.ProtocolInfo (ProtocolConfigPath, getProtocolConfigPath, loadNodeConfig)
 import Hoard.Effects.Conc (Conc, fork_)
 import Hoard.Effects.Log (Log)
-import Hoard.Effects.NodeToNode (loadNodeConfig)
 
 
 data NodeToClient :: Effect where
@@ -83,7 +83,7 @@ runNodeToClient'
     :: ( Conc :> es
        , Log :> es
        , IOE :> es
-       , HasField "protocolConfigPath" config FilePath
+       , HasField "protocolConfigPath" config ProtocolConfigPath
        , HasField "localNodeSocketPath" config FilePath
        )
     => config
@@ -92,7 +92,7 @@ runNodeToClient'
 runNodeToClient' config nodeToClient = do
     (immutableTipQueriesIn, immutableTipQueriesOut) <- liftIO newChan
     (isOnChainQueriesIn, isOnChainQueriesOut) <- liftIO newChan
-    epochSize <- loadEpochSize config.protocolConfigPath
+    epochSize <- loadEpochSize $ getProtocolConfigPath config.protocolConfigPath
     _ <-
         withExceptionLogging "NodeToClient"
             . fork_

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -4,8 +4,10 @@ import Effectful (Eff, (:>))
 import Effectful.Concurrent (threadDelay)
 import Effectful.State.Static.Shared (State, modify)
 import Hoard.Collector (dispatchDiscoveredNodes)
+import Hoard.Data.ProtocolInfo (ProtocolConfigPath)
 import Hoard.Effects (AppEff)
 import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.Input (Input)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.NodeToClient qualified as N
 import Hoard.Effects.Sub (listen)
@@ -16,10 +18,16 @@ import Hoard.Listeners.NetworkEventListener (networkEventListener)
 import Hoard.Listeners.PeerSharingEventListener (peerSharingEventListener)
 import Hoard.Listeners.PeersReceivedListener (peersReceivedListener)
 import Hoard.Types.HoardState (HoardState (immutableTip))
+import Ouroboros.Network.IOManager (IOManager)
 import Prelude hiding (State, modify)
 
 
-runListeners :: (AppEff es) => Eff es ()
+runListeners
+    :: ( AppEff es
+       , Input IOManager :> es
+       , Input ProtocolConfigPath :> es
+       )
+    => Eff es ()
 runListeners = do
     refreshImmutableTip
     _ <- Conc.fork $ listen headerReceivedListener


### PR DESCRIPTION
This allows the users of `connectToPeer` to interpret the effects it uses differently.

To keep the arguments of `connecToPeer` somewhat similar, `IOManager` and `ProtocolConfigPath` are now supplied through the effect system instead of as arguments, as they were for `connectToPeerImpl`. To improve ergonomics of supplying `ProtocolConfigPath` through the `Input` effect, everything regarding node config and `ProtocolInfo` is moved to a separate module, wherein `ProtocolConfigPath` is a `newtype` around a `FilePath` pointing to the config file in question. This also makes it so that `NodeToClient` does not import `NodeToNode`, which hurt my soul a bit upon discovering it while working on this PR.

Removes `disconnectPeer` and `isConnected`, since `connectToPeer` is a blocking action, and blocks as long as the peer is connected.