### PR TITLE
refactor: pass handlers to connectToPeer for better control

### DIFF
--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -3,28 +3,40 @@ module Hoard.Collector (dispatchDiscoveredNodes, runCollector) where
 import Control.Concurrent (threadDelay)
 import Data.Set qualified as S
 import Effectful (Eff, IOE, (:>))
-
 import Effectful.Exception (bracket)
 import Effectful.State.Static.Shared (State, gets, modify, state)
+import Prelude hiding (State, gets, modify, state)
+
 import Hoard.Control.Exception (withExceptionLogging)
 import Hoard.Data.Peer (Peer (..))
+import Hoard.Effects.Chan (Chan)
+import Hoard.Effects.Chan qualified as Chan
 import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Clock qualified as Clock
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.Input (Input, input, runInputChan)
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.NodeToNode (NodeToNode, connectToPeer)
+import Hoard.Effects.NodeToNode (Config (..), NodeToNode, connectToPeer)
+import Hoard.Effects.NodeToNode qualified as NodeToNode
+import Hoard.Effects.Output (Output, output, runOutputChan)
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Effects.Pub (Pub, publish)
 import Hoard.Events.Collector (CollectorEvent (..))
-import Hoard.Network.Events (PeerSharingEvent (..), PeersReceivedData (..))
+import Hoard.Network.Events
+    ( BlockFetchRequest (..)
+    , BlockReceivedData (..)
+    , HeaderReceivedData (..)
+    , PeerSharingEvent (..)
+    , PeersReceivedData (..)
+    )
 import Hoard.Types.HoardState (HoardState, connectedPeers)
-import Prelude hiding (State, gets, modify, state)
 
 
 dispatchDiscoveredNodes
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , IOE :> es
        , Log :> es
        , NodeToNode :> es
@@ -64,17 +76,66 @@ dispatchDiscoveredNodes = \case
 
 
 runCollector
-    :: (IOE :> es, NodeToNode :> es, Pub :> es)
+    :: ( Conc :> es
+       , Chan :> es
+       , IOE :> es
+       , NodeToNode :> es
+       , Pub :> es
+       )
     => Peer
     -> Eff es Void
-runCollector peer = do
-    publish $ CollectorStarted peer.address
-    publish $ ConnectingToPeer peer.address
+runCollector peer =
+    withBridge @BlockFetchRequest
+        . withBridge @HeaderReceivedData
+        . withBridge @BlockReceivedData
+        $ do
+            publish $ CollectorStarted peer.address
+            publish $ ConnectingToPeer peer.address
 
-    _conn <- connectToPeer peer
-    publish $ ConnectedToPeer peer.address
+            Conc.fork_ pickBlockFetchRequest
+            _conn <-
+                connectToPeer $
+                    NodeToNode.Config
+                        { peer
+                        , emitFetchedHeader = output
+                        , emitFetchedBlock = output
+                        , awaitBlockFetchRequest = input
+                        }
+            publish $ ConnectedToPeer peer.address
 
-    -- Connection is now running autonomously!
-    -- Protocols publish events as they receive data
-    -- For now, just keep the collector alive
-    forever $ liftIO $ threadDelay 1000000
+            -- Connection is now running autonomously!
+            -- Protocols publish events as they receive data
+            -- For now, just keep the collector alive
+            forever $ liftIO $ threadDelay 1000000
+
+
+-- | Re-emit `HeaderReceived` events as `BlockFetchRequests`.
+pickBlockFetchRequest
+    :: ( Input HeaderReceivedData :> es
+       , Output BlockFetchRequest :> es
+       )
+    => Eff es Void
+pickBlockFetchRequest = forever do
+    dat <- input
+    output $
+        BlockFetchRequest
+            { timestamp = dat.timestamp
+            , point = dat.point
+            , peer = dat.peer.address
+            }
+
+
+-- | Bridge effects through bidirectional channels.
+--
+-- Creates a channel pair and interprets Input/Output effects over them,
+-- enabling communication between threads.
+--
+-- This function:
+-- 1. Creates a bidirectional channel pair using 'Chan.newChan'
+-- 2. Interprets 'Input' and 'Output' effects over these channels
+-- 3. Provides these effects to the wrapped action
+-- 4. The action can fork threads that communicate via these effects
+withBridge :: forall b es a. (Chan :> es) => Eff (Input b : Output b : es) a -> Eff es a
+withBridge action = do
+    (inChan, outChan) <- Chan.newChan
+    runOutputChan inChan . runInputChan outChan $ action


### PR DESCRIPTION
An alternative to https://github.com/tweag/cardano-hoarding-node/pull/125.

This allows us to evaluate most of our business logic (like, whether a block should be fetched or not) from the `Collector` instead of inside `NodeToNode`.