### PR TITLE
refactor: extract environment types to dedicated module

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -69,6 +69,7 @@ library
       Hoard.Types.Collector
       Hoard.Types.DBConfig
       Hoard.Types.Deployment
+      Hoard.Types.Environment
       Hoard.Types.Header
       Hoard.Types.HoardState
       Hoard.Types.JsonReadShow

--- a/src/Hoard/Config/Loader.hs
+++ b/src/Hoard/Config/Loader.hs
@@ -15,10 +15,10 @@ import System.IO.Error (userError)
 import Data.Yaml qualified as Yaml
 
 import Data.String.Conversions (cs)
-import Hoard.Effects (Config (..), Env (..), Handles (..), ServerConfig (..))
 import Hoard.Effects.Log qualified as Log
 import Hoard.Types.DBConfig (DBConfig (..), PoolConfig (..), acquireDatabasePools)
 import Hoard.Types.Deployment (Deployment, deploymentName)
+import Hoard.Types.Environment (Config (..), Env (..), Handles (..), ServerConfig (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -3,11 +3,6 @@ module Hoard.Effects
       runEffectStack
     , AppEff
     , AppEffects
-    -- Config
-    , Config (..)
-    , Handles (..)
-    , Env (..)
-    , ServerConfig (..)
 
       -- * Type Aliases
     , type (::>)
@@ -17,66 +12,29 @@ where
 import Prelude hiding (State, evalState)
 
 import Control.Exception (throwIO)
-import Data.Aeson (FromJSON)
 import Data.Default (def)
-import Data.Dynamic (Dynamic)
 import Effectful (Eff, IOE, runEff, (:>))
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Error.Static (Error, runErrorNoCallStack)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.State.Static.Shared (State, evalState)
-import Ouroboros.Network.IOManager (IOManager)
 import System.IO.Error (userError)
 
-import Hoard.Effects.Chan (Chan, InChan, runChan)
+import Hoard.Effects.Chan (Chan, runChan)
 import Hoard.Effects.Clock (Clock, runClock)
 import Hoard.Effects.Conc (Conc, runConcNewScope)
 import Hoard.Effects.DBRead (DBRead, runDBRead)
 import Hoard.Effects.DBWrite (DBWrite, runDBWrite)
 import Hoard.Effects.HeaderRepo (HeaderRepo, runHeaderRepo)
 import Hoard.Effects.Log (Log, runLog)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.NodeToClient (NodeToClient, runNodeToClient)
 import Hoard.Effects.NodeToNode (NodeToNode, runNodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, runPeerRepo)
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, runSub)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.Environment (Config (..), Env (..), Handles (..))
 import Hoard.Types.HoardState (HoardState)
-import Hoard.Types.QuietSnake (QuietSnake (..))
-
-
--- | HTTP server configuration
-data ServerConfig = ServerConfig
-    { host :: Text
-    , port :: Word16
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON) via QuietSnake ServerConfig
-
-
--- | Pure configuration data loaded from config files
-data Config = Config
-    { server :: ServerConfig
-    , protocolConfigPath :: FilePath
-    , localNodeSocketPath :: FilePath
-    , logging :: Log.Config
-    }
-
-
--- | Runtime handles and resources
-data Handles = Handles
-    { ioManager :: IOManager
-    , dbPools :: DBPools
-    , inChan :: InChan Dynamic
-    }
-
-
--- | Application environment combining config and handles
-data Env = Env
-    { config :: Config
-    , handles :: Handles
-    }
 
 
 -- | Constraint alias for application effects

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -1,0 +1,49 @@
+module Hoard.Types.Environment
+    ( ServerConfig (..)
+    , Config (..)
+    , Handles (..)
+    , Env (..)
+    )
+where
+
+import Data.Aeson (FromJSON)
+import Data.Dynamic (Dynamic)
+import Ouroboros.Network.IOManager (IOManager)
+
+import Hoard.Effects.Chan (InChan)
+import Hoard.Effects.Log qualified as Log
+import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+
+-- | HTTP server configuration
+data ServerConfig = ServerConfig
+    { host :: Text
+    , port :: Word16
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake ServerConfig
+
+
+-- | Pure configuration data loaded from config files
+data Config = Config
+    { server :: ServerConfig
+    , protocolConfigPath :: FilePath
+    , localNodeSocketPath :: FilePath
+    , logging :: Log.Config
+    }
+
+
+-- | Runtime handles and resources
+data Handles = Handles
+    { ioManager :: IOManager
+    , dbPools :: DBPools
+    , inChan :: InChan Dynamic
+    }
+
+
+-- | Application environment combining config and handles
+data Env = Env
+    { config :: Config
+    , handles :: Handles
+    }

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -41,12 +41,13 @@ import Hasql.Pool qualified as Pool
 import Hasql.Pool.Config qualified as Pool
 
 import Hoard.API (API, Routes, server)
-import Hoard.Effects (Config (..), Env (..), Handles (..), ServerConfig (..), runEffectStack)
+import Hoard.Effects (runEffectStack)
 import Hoard.Effects.Log (Log, runLog)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, runSub)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.Environment (Config (..), Env (..), Handles (..), ServerConfig (..))
 import Hoard.Types.HoardState (HoardState)
 
 


### PR DESCRIPTION
Move Config, Handles, Env, and ServerConfig from Hoard.Effects to new Hoard.Types.Environment module to better separate concerns between configuration/runtime data and effect stack implementation.

Update imports in Server, Config.Loader, and TestHelpers to use the new module directly.