### PR TITLE
feat: check database for known peers before bootstrapping

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -10,7 +10,7 @@ import Hoard.Effects (runEffectStack)
 import Hoard.Listeners (runListeners)
 import Hoard.Types.Deployment (Deployment (..))
 
-import Hoard.Bootstrap (bootstrapCollection)
+import Hoard.Collector (runCollectors)
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Server (runServer)
 
@@ -28,5 +28,5 @@ main = withIOManager $ \ioManager -> do
     runEffectStack env $ do
         runServer env
         runListeners
-        bootstrapCollection
+        runCollectors
         Conc.awaitAll

--- a/src/Hoard/Bootstrap.hs
+++ b/src/Hoard/Bootstrap.hs
@@ -1,40 +1,17 @@
-module Hoard.Bootstrap (bootstrapCollection) where
+module Hoard.Bootstrap (bootstrapPeer) where
 
 import Data.IP (IP)
 import Data.IP qualified as IP
 import Data.Set qualified as S
 import Effectful (Eff, IOE, (:>))
-import Network.Socket (PortNumber)
+import Network.Socket (HostName, PortNumber)
 import Network.Socket qualified as Socket
-import Prelude hiding (State, evalState)
 
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Clock qualified as Clock
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Types.NodeIP (NodeIP (..))
-
-import Hoard.Collector (runCollector)
-import Hoard.Effects.Chan (Chan)
-import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.NodeToNode (NodeToNode)
-import Hoard.Effects.Pub (Pub)
-
-
-bootstrapCollection
-    :: ( Pub :> es
-       , NodeToNode :> es
-       , Chan :> es
-       , Conc :> es
-       , PeerRepo :> es
-       , Clock :> es
-       , IOE :> es
-       )
-    => Eff es ()
-bootstrapCollection = do
-    peer <- bootstrapPeer
-    _ <- runCollector peer
-    pure ()
 
 
 bootstrapPeer :: (PeerRepo :> es, Clock :> es, IOE :> es) => Eff es Peer
@@ -57,7 +34,7 @@ bootstrapPeer = do
         _ -> error "Expected exactly one peer from upsert"
 
 
-resolvePeerAddress :: Text -> Int -> IO (IP, PortNumber)
+resolvePeerAddress :: HostName -> Int -> IO (IP, PortNumber)
 resolvePeerAddress address port = do
     let hints = Socket.defaultHints {Socket.addrSocketType = Socket.Stream}
     addrs <- Socket.getAddrInfo (Just hints) (Just $ toString address) (Just $ show port)


### PR DESCRIPTION
Changes bootstrap logic to query the database first:
- If peers exist in database, start collectors for all of them
- If no peers exist, bootstrap from hardcoded preview-node peer
- Add getAllPeers operation to PeerRepo effect
- Extract forkCollector helper with exception handling and state management
- Add debug logging to show which path is taken and peer count

Now we're cooking:

```
hoard_dev=# select count (*) from hoard.headers;
 count
-------
     3
(1 row)

hoard_dev=# select count (*) from hoard.peers;
 count
-------
  1132
(1 row)
```