### PR TITLE
refactor: move Log config to Hoard.Types.Environment

### DIFF
--- a/src/Hoard/Config/Loader.hs
+++ b/src/Hoard/Config/Loader.hs
@@ -18,11 +18,18 @@ import Ouroboros.Network.IOManager (IOManager)
 import System.FilePath ((</>))
 import System.IO.Error (userError)
 
-import Hoard.Effects.Log qualified as Log
 import Hoard.Types.Cardano (CardanoBlock)
 import Hoard.Types.DBConfig (DBConfig (..), PoolConfig (..), acquireDatabasePools)
 import Hoard.Types.Deployment (Deployment, deploymentName)
-import Hoard.Types.Environment (Config (..), Env (..), Handles (..), ServerConfig (..))
+import Hoard.Types.Environment
+    ( Config (..)
+    , Env (..)
+    , Handles (..)
+    , ServerConfig (..)
+    , Severity (..)
+    , defaultLogConfig
+    )
+import Hoard.Types.Environment qualified as Log (LogConfig (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 
@@ -122,7 +129,7 @@ toDBConfig dbCfg credentials =
 
 
 data LoggingConfig = LoggingConfig
-    { minimumSeverity :: Log.Severity
+    { minimumSeverity :: Severity
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake LoggingConfig
@@ -148,10 +155,10 @@ loadEnv ioManager deployment = do
         log <- (>>= readMaybe) <$> lookupEnv "LOG"
         logging <- (>>= readMaybe) <$> lookupEnv "LOGGING"
         debug <-
-            (>>= \x -> if x == "0" then Nothing else Just Log.DEBUG)
+            (>>= \x -> if x == "0" then Nothing else Just DEBUG)
                 <$> lookupEnv "DEBUG"
         let minimumSeverity = fromMaybe configFile.logging.minimumSeverity $ debug <|> logging <|> log
-        pure $ Log.defaultConfig {Log.minimumSeverity}
+        pure $ defaultLogConfig {Log.minimumSeverity}
 
     let config =
             Config

--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -97,6 +97,7 @@ import Hoard.Network.Events
     )
 import Hoard.Network.Types (Connection (..))
 import Hoard.Types.Cardano (CardanoBlock, CardanoHeader, CardanoPoint, CardanoTip)
+import Hoard.Types.Environment qualified as Log (Severity (..))
 
 import Data.IP qualified as IP
 import Data.Set qualified as S

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -1,8 +1,11 @@
 module Hoard.Types.Environment
     ( ServerConfig (..)
+    , LogConfig (..)
+    , Severity (..)
     , Config (..)
     , Handles (..)
     , Env (..)
+    , defaultLogConfig
     )
 where
 
@@ -13,9 +16,9 @@ import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo)
 import Ouroboros.Network.IOManager (IOManager)
 
 import Hoard.Effects.Chan (InChan)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Types.Cardano (CardanoBlock)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.JsonReadShow (JsonReadShow (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 
@@ -28,11 +31,34 @@ data ServerConfig = ServerConfig
     deriving (FromJSON) via QuietSnake ServerConfig
 
 
+data LogConfig = LogConfig
+    { minimumSeverity :: Severity
+    , output :: Handle
+    }
+
+
+data Severity
+    = DEBUG
+    | INFO
+    | WARN
+    | ERROR
+    deriving stock (Eq, Ord, Enum, Bounded, Show, Read)
+    deriving (FromJSON) via (JsonReadShow Severity)
+
+
+defaultLogConfig :: LogConfig
+defaultLogConfig =
+    LogConfig
+        { minimumSeverity = minBound
+        , output = stdout
+        }
+
+
 -- | Pure configuration data loaded from config files
 data Config = Config
     { server :: ServerConfig
     , localNodeSocketPath :: FilePath
-    , logging :: Log.Config
+    , logging :: LogConfig
     , protocolInfo :: ProtocolInfo CardanoBlock
     , nodeConfig :: NodeConfig
     }

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -44,11 +44,16 @@ import Hoard.API (API, Routes, server)
 import Hoard.Config.Loader (loadNodeConfig, loadProtocolInfo)
 import Hoard.Effects (runEffectStack)
 import Hoard.Effects.Log (Log, runLog)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Pub (Pub, runPub)
 import Hoard.Effects.Sub (Sub, runSub)
 import Hoard.Types.DBConfig (DBPools (..))
-import Hoard.Types.Environment (Config (..), Env (..), Handles (..), ServerConfig (..))
+import Hoard.Types.Environment
+    ( Config (..)
+    , Env (..)
+    , Handles (..)
+    , ServerConfig (..)
+    , defaultLogConfig
+    )
 import Hoard.Types.HoardState (HoardState)
 
 
@@ -101,7 +106,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , nodeConfig
                 , protocolInfo
                 , localNodeSocketPath = "preview.socket"
-                , logging = Log.defaultConfig
+                , logging = defaultLogConfig
                 }
     let handles =
             Handles

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -14,6 +14,7 @@ import Hoard.Effects.DBWrite (runDBWrite, runTransaction)
 import Hoard.Effects.Log qualified as Log
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.Environment (defaultLogConfig)
 
 
 spec_DBEffects :: Spec
@@ -35,7 +36,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First write some data
             _ <-
                 runEff
-                    . Log.runLog Log.defaultConfig
+                    . Log.runLog defaultLogConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert-test"
@@ -57,7 +58,7 @@ spec_DBEffects = withCleanTestDatabase $ do
         it "can write to the database" $ \config -> do
             result <-
                 runEff
-                    . Log.runLog Log.defaultConfig
+                    . Log.runLog defaultLogConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert-test"
@@ -70,7 +71,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First insert
             _ <-
                 runEff
-                    . Log.runLog Log.defaultConfig
+                    . Log.runLog defaultLogConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "insert"
@@ -79,7 +80,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- Then delete
             result <-
                 runEff
-                    . Log.runLog Log.defaultConfig
+                    . Log.runLog defaultLogConfig
                     . runErrorNoCallStack @Text
                     . runDBWrite config.pools.writerPool
                     $ runTransaction "delete"

--- a/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
@@ -22,6 +22,7 @@ import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo (runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.Environment (defaultLogConfig)
 import Text.Read (read)
 
 
@@ -29,7 +30,7 @@ spec_HeaderPersistence :: Spec
 spec_HeaderPersistence = do
     let runWrite config action =
             runEff
-                . Log.runLog Log.defaultConfig
+                . Log.runLog defaultLogConfig
                 . runErrorNoCallStack @Text
                 . runDBRead config.pools.readerPool
                 . runDBWrite config.pools.writerPool

--- a/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
@@ -18,6 +18,7 @@ import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo (getPeerByAddress, runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.Environment (defaultLogConfig)
 import Text.Read (read)
 
 
@@ -25,7 +26,7 @@ spec_PeerPersistence :: Spec
 spec_PeerPersistence = do
     let runWrite config action =
             runEff
-                . Log.runLog Log.defaultConfig
+                . Log.runLog defaultLogConfig
                 . runErrorNoCallStack @Text
                 . runDBRead config.pools.readerPool
                 . runDBWrite config.pools.writerPool


### PR DESCRIPTION
First step in a series of PRs implementing [this suggestion](https://moduscreate.slack.com/archives/C09B1PLP6TU/p1766061430861539?thread_ts=1766061019.052389&cid=C09B1PLP6TU). It's a nice cleanup regardless whether we follow up on that suggestion though.