### PR TITLE
feat: accept DB config from env vars

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
 use flake
 watch_file ./nix/*
 watch_file ./hoard.cabal
+dotenv_if_exists '.env.local'

--- a/nix/postgres.nix
+++ b/nix/postgres.nix
@@ -18,9 +18,9 @@
       fi
 
       # Parse config values from YAML
-      DB_HOST=$(${pkgs.yq-go}/bin/yq '.database.host' "$CONFIG_FILE")
-      DB_PORT=$(${pkgs.yq-go}/bin/yq '.database.port' "$CONFIG_FILE")
-      DB_NAME=$(${pkgs.yq-go}/bin/yq '.database.database_name' "$CONFIG_FILE")
+      DB_HOST=''${DB_HOST:-$(${pkgs.yq-go}/bin/yq '.database.host' "$CONFIG_FILE")}
+      DB_PORT=''${DB_PORT:-$(${pkgs.yq-go}/bin/yq '.database.port' "$CONFIG_FILE")}
+      DB_NAME=''${DB_NAME:-$(${pkgs.yq-go}/bin/yq '.database.database_name' "$CONFIG_FILE")}
 
       echo "Loading configuration from: $CONFIG_FILE"
       echo "  Database: $DB_NAME"


### PR DESCRIPTION
Allows other people than @cgeorgii to run the postgres server without having to change tracked files locally 😅 

We might want to swap how we read our config for a library where you just define your config types, and are then able to apply those types to parsed CLI arguments as well as YAML files, instead of manually pulling out `DB_HOST`, etc. like this.

Rebased onto https://github.com/tweag/cardano-hoarding-node/pull/139
Depends on https://github.com/tweag/cardano-hoarding-node/pull/139