### PR TITLE
ci: add executable build to flake checks

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -150,5 +150,7 @@ in
   # Checks
   checks = projectFlake.checks // {
     git-hooks = gitHooks;
+    # Ensure the executable builds in CI
+    hoard-exe = projectFlake.packages."hoard:exe:hoard-exe";
   };
 }


### PR DESCRIPTION
Ensure hoard-exe is built during CI by including it in flake checks. This prevents compilation errors in the executable from being missed while avoiding duplicate builds of the library.