### PR TITLE
refactor: fix Rel8 schema conversion helpers

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -179,8 +179,19 @@ schema = mkSchema "peers"
 
 -- Conversion functions
 peerFromRow :: Row Result -> Peer
-rowFromPeer :: Peer -> Row Result
+peerFromRow row = Peer { ... }
+
+-- For inserting into database, wrap values with lit
+rowFromPeer :: Peer -> Row Expr
+rowFromPeer peer = Row
+  { id = lit peer.peerId
+  , address = lit peer.address
+  , port = lit peer.port
+  -- ... other fields wrapped with lit
+  }
 ```
+
+**Important**: Use `Row Expr` (not `Row Result`) for the domain-to-row conversion. Each field value must be wrapped with `lit` to convert it to an expression suitable for database operations.
 
 **3. Migration** (`db/deploy/create_peers_table.sql`):
 

--- a/src/Hoard/DB/Schemas/Blocks.hs
+++ b/src/Hoard/DB/Schemas/Blocks.hs
@@ -8,10 +8,12 @@ module Hoard.DB.Schemas.Blocks
 import Data.Time (UTCTime)
 import Rel8
     ( Column
+    , Expr
     , Name
     , Rel8able
     , Result
     , TableSchema
+    , lit
     )
 
 import Hoard.DB.Schema (mkSchema)
@@ -59,16 +61,16 @@ blockFromRow row = do
             }
 
 
-rowFromBlock :: Block -> Row Result
+rowFromBlock :: Block -> Row Expr
 rowFromBlock blk = do
     Row
-        { hash = blk.hash
-        , slotNumber = blk.slotNumber
-        , poolId = blk.poolId
-        , blockEra = blockToEra blk.blockData
-        , blockData = encodeCardanoBlock blk.blockData
-        , validationStatus = blk.validationStatus
-        , validationReason = blk.validationReason
-        , isCanonical = blk.isCanonical
-        , firstSeen = blk.firstSeen
+        { hash = lit blk.hash
+        , slotNumber = lit blk.slotNumber
+        , poolId = lit blk.poolId
+        , blockEra = lit $ blockToEra blk.blockData
+        , blockData = lit $ encodeCardanoBlock blk.blockData
+        , validationStatus = lit blk.validationStatus
+        , validationReason = lit blk.validationReason
+        , isCanonical = lit blk.isCanonical
+        , firstSeen = lit blk.firstSeen
         }

--- a/src/Hoard/DB/Schemas/HeaderReceipts.hs
+++ b/src/Hoard/DB/Schemas/HeaderReceipts.hs
@@ -9,10 +9,12 @@ where
 import Data.Time (UTCTime)
 import Rel8
     ( Column
+    , Expr
     , Name
     , Rel8able
     , Result
     , TableSchema
+    , lit
     )
 
 import Hoard.DB.Schema (mkSchema)
@@ -55,11 +57,11 @@ headerReceiptFromRow row =
 
 
 -- | Convert a HeaderReceipt domain type to a database row
-rowFromHeaderReceipt :: HeaderReceipt -> Row Result
+rowFromHeaderReceipt :: HeaderReceipt -> Row Expr
 rowFromHeaderReceipt receipt =
     Row
-        { id = receipt.id
-        , hash = receipt.hash
-        , peerId = receipt.peerId
-        , receivedAt = receipt.receivedAt
+        { id = lit receipt.id
+        , hash = lit receipt.hash
+        , peerId = lit receipt.peerId
+        , receivedAt = lit receipt.receivedAt
         }

--- a/src/Hoard/Effects/BlockRepo.hs
+++ b/src/Hoard/Effects/BlockRepo.hs
@@ -14,10 +14,10 @@ import Rel8 (in_, lit, where_)
 import Rel8 qualified
 
 import Hasql.Statement (Statement)
+import Hoard.DB.Schemas.Blocks (rowFromBlock)
 import Hoard.DB.Schemas.Blocks qualified as Blocks
-import Hoard.Data.Block (Block (..), encodeCardanoBlock)
+import Hoard.Data.Block (Block (..))
 import Hoard.Data.BlockHash (blockHashFromHeader)
-import Hoard.Data.Eras (blockToEra)
 import Hoard.Effects.DBRead (DBRead, runQuery)
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
 import Hoard.Types.Cardano (CardanoHeader)
@@ -48,20 +48,7 @@ insertBlocksTrans blocks =
         $ Rel8.insert
             Rel8.Insert
                 { into = Blocks.schema
-                , rows =
-                    Rel8.values $
-                        blocks <&> \block ->
-                            Blocks.Row
-                                { hash = lit block.hash
-                                , slotNumber = lit block.slotNumber
-                                , poolId = lit block.poolId
-                                , blockEra = lit $ blockToEra block.blockData
-                                , blockData = lit $ encodeCardanoBlock block.blockData
-                                , validationStatus = lit block.validationStatus
-                                , validationReason = lit block.validationReason
-                                , isCanonical = lit block.isCanonical
-                                , firstSeen = lit block.firstSeen
-                                }
+                , rows = Rel8.values $ rowFromBlock <$> blocks
                 , onConflict = Rel8.DoNothing
                 , returning = Rel8.NoReturning
                 }


### PR DESCRIPTION
Fix rowFrom* functions to return `Row Expr` instead of `Row Result`.

- Update `rowFromBlock` to use Row Expr with lit-wrapped fields
- Update `rowFromHeaderReceipt` to use Row Expr with lit-wrapped fields
- Refactor `BlockRepo` to use `rowFromBlock` helper instead of manual Row construction
- Update db/README.md documentation with correct pattern and examples

This ensures schema conversion functions work correctly for inserts and other database operations requiring expressions.