### PR TITLE
refactor: make logging thread-safe with channel-based worker

### DIFF
--- a/src/Hoard/Bootstrap.hs
+++ b/src/Hoard/Bootstrap.hs
@@ -8,8 +8,6 @@ import Network.Socket (HostName, PortNumber)
 import Network.Socket qualified as Socket
 
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
-import Hoard.Effects.BlockRepo (BlockRepo)
-import Hoard.Effects.Chan (Chan)
 import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Clock qualified as Clock
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)

--- a/src/Hoard/Effects.hs
+++ b/src/Hoard/Effects.hs
@@ -93,7 +93,6 @@ type AppEffects =
      , Labeled "nodeToClient" WithSocket
      , Labeled "tracer" WithSocket
      , Temporary
-     , Conc
      , Concurrent
      , FileSystem
      , Clock
@@ -104,6 +103,7 @@ type AppEffects =
      , Reader Config
      , Reader Env
      , Reader Options
+     , Conc
      , Chan
      , IOE
      ]
@@ -115,6 +115,7 @@ runEffectStack action = liftIO $ do
     result <-
         runEff
             . runChan
+            . runConcNewScope
             . loadOptions
             . loadEnv
             . runConfigReader
@@ -123,7 +124,6 @@ runEffectStack action = liftIO $ do
             . runClock
             . runFileSystem
             . runConcurrent
-            . runConcNewScope
             . runTemporary
             . withNodeSockets
             . runNodeToClient

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -30,6 +30,7 @@ import Effectful.State.Static.Shared (State, runState)
 import Hasql.Pool qualified as Pool
 import Hasql.Pool.Config qualified as Pool
 import Hoard.Effects.Chan (Chan, OutChan, runChan)
+import Hoard.Effects.Conc (Conc, runConcNewScope)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp (testWithApplication)
@@ -137,6 +138,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
             . runFileSystem
             . runConcurrent
             . runChan
+            . runConcNewScope
             . runReader env.config.logging
             . runReader env.handles.inChan
             . runLog
@@ -162,6 +164,7 @@ type TestAppEffs =
     , Log
     , Reader (InChan Dynamic)
     , Reader LogConfig
+    , Conc
     , Chan
     , Concurrent
     , FileSystem

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -37,8 +37,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First write some data
             _ <-
                 runEff
-                    . runReader defaultLogConfig
-                    . Log.runLog
+                    . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runDBWrite
@@ -63,7 +62,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             result <-
                 runEff
                     . runReader defaultLogConfig
-                    . Log.runLog
+                    . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runDBWrite
@@ -78,7 +77,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             _ <-
                 runEff
                     . runReader defaultLogConfig
-                    . Log.runLog
+                    . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runDBWrite
@@ -89,7 +88,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             result <-
                 runEff
                     . runReader defaultLogConfig
-                    . Log.runLog
+                    . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runDBWrite

--- a/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
@@ -23,17 +23,15 @@ import Hoard.Effects.HeaderRepo (runHeaderRepo, upsertHeader)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo (runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
-import Hoard.Types.Environment (defaultLogConfig)
 
 
 spec_HeaderPersistence :: Spec
 spec_HeaderPersistence = do
     let runWrite config action =
             runEff
-                . runReader defaultLogConfig
-                . runReader config.pools
-                . Log.runLog
+                . Log.runLogNoOp
                 . runErrorNoCallStack @Text
+                . runReader config.pools
                 . runDBRead
                 . runDBWrite
                 . runPeerRepo

--- a/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/PeerPersistenceSpec.hs
@@ -19,15 +19,13 @@ import Hoard.Effects.DBWrite (runDBWrite)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo (getPeerByAddress, runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
-import Hoard.Types.Environment (defaultLogConfig)
 
 
 spec_PeerPersistence :: Spec
 spec_PeerPersistence = do
     let runWrite config action =
             runEff
-                . runReader defaultLogConfig
-                . Log.runLog
+                . Log.runLogNoOp
                 . runErrorNoCallStack @Text
                 . runReader config.pools
                 . runDBRead


### PR DESCRIPTION
Implement thread-safe logging using channels to prevent interleaved log messages from concurrent threads.

Changes:
- Modified `runLog` to spawn a dedicated worker thread that reads from a channel and writes to the handle sequentially
- Updated effect stack to make `Chan` and `Conc` available when `runLog` runs
- Tests now use `runLogNoOp` to avoid needing the full effect stack