### PR TITLE
feat: use immutable tip for chain sync intersection

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -53,13 +53,13 @@ main =
         . runSub
         . runPub
         . runErrorThrowing
+        . evalState @HoardState def
         . runNodeToNode
         . runDBRead
         . runDBWrite
         . runHeaderRepo
         . runPeerRepo
         . runBlockRepo
-        . evalState @HoardState def
         $ do
             setup
             runServer

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -9,8 +9,8 @@ secrets_file: secrets/dev.yaml
 node_sockets:
   tag: Local
   contents:
-    node_to_client_socket: preprod.socket
-    tracer_socket: preprod_tracer.socket
+    node_to_client_socket: node-db/preprod/node.socket
+    tracer_socket: /tmp/cardano-tracer.sock
 
 # Path to Cardano protocol config file
 protocol_config_path: config/preprod/config.json

--- a/src/Hoard/Effects/NodeToClient.hs
+++ b/src/Hoard/Effects/NodeToClient.hs
@@ -1,4 +1,3 @@
--- to do. remove after issue 102
 {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-redundant-constraints #-}
 
 module Hoard.Effects.NodeToClient
@@ -65,7 +64,6 @@ data NodeToClient :: Effect where
 makeEffect ''NodeToClient
 
 
--- to do. remove after issue 102
 runNodeToClient
     :: ( Labeled "nodeToClient" WithSocket :> es
        , Conc :> es
@@ -75,21 +73,7 @@ runNodeToClient
        )
     => Eff (NodeToClient : es) a
     -> Eff es a
-runNodeToClient = interpret_ $ \case
-    ImmutableTip -> pure C.ChainPointAtGenesis
-    IsOnChain _ -> pure False
-
-
-runNodeToClient'
-    :: ( Labeled "nodeToClient" WithSocket :> es
-       , Conc :> es
-       , Log :> es
-       , IOE :> es
-       , Reader Config :> es
-       )
-    => Eff (NodeToClient : es) a
-    -> Eff es a
-runNodeToClient' nodeToClient = do
+runNodeToClient nodeToClient = do
     config <- ask
     (immutableTipQueriesIn, immutableTipQueriesOut) <- liftIO newChan
     (isOnChainQueriesIn, isOnChainQueriesOut) <- liftIO newChan

--- a/src/Hoard/Setup.hs
+++ b/src/Hoard/Setup.hs
@@ -9,12 +9,16 @@ module Hoard.Setup
 
 import Effectful (Eff, IOE, (:>))
 import Effectful.Reader.Static (Reader, asks)
+import Effectful.State.Static.Shared (State, modify)
 import System.Posix.Resource (Resource (..), ResourceLimit (..), ResourceLimits (..), getResourceLimit, setResourceLimit)
-import Prelude hiding (Reader, asks)
+import Prelude hiding (Reader, State, asks, modify)
 
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.NodeToClient (NodeToClient)
+import Hoard.Effects.NodeToClient qualified as N
 import Hoard.Types.Environment (Config (..))
+import Hoard.Types.HoardState (HoardState (..))
 
 
 -- | Default file descriptor limit (8192)
@@ -35,14 +39,35 @@ defaultMaxFileDescriptors = 8192
 -- Should be called early in the application startup, before opening many files
 -- or network connections.
 setup
-    :: (IOE :> es, Log :> es, Reader Config :> es)
+    :: ( IOE :> es
+       , Log :> es
+       , Reader Config :> es
+       , NodeToClient :> es
+       , State HoardState :> es
+       )
     => Eff es ()
 setup = do
     Log.info "Running application setup..."
 
     setFileDescriptorLimit
+    fetchAndStoreImmutableTip
 
     Log.info "Application setup complete"
+
+
+-- | Fetch the immutable tip from the cardano-node and store it in HoardState.
+--
+-- This is called during application setup to initialize the immutable tip
+-- before we start connecting to peers. If the NodeToClient connection fails,
+-- the HoardState will retain its default value (ChainPointAtGenesis).
+fetchAndStoreImmutableTip
+    :: (NodeToClient :> es, State HoardState :> es, Log :> es)
+    => Eff es ()
+fetchAndStoreImmutableTip = do
+    Log.info "Fetching immutable tip from cardano-node..."
+    tip <- N.immutableTip
+    Log.info $ "Immutable tip: " <> show tip
+    modify (\hoardState -> hoardState {immutableTip = tip})
 
 
 -- | Set the file descriptor limit (soft limit) to the specified value.


### PR DESCRIPTION
Fetch the immutable tip from `cardano-node` at startup and use it as the
initial intersection point when syncing with peers, falling back to
genesis if the peer doesn't have the immutable tip block yet.

This improves sync performance by starting from a more recent point in
the chain rather than always starting from genesis.

Changes:
- Enable real `NodeToClient` implementation to query cardano-node
- Add `fetchAndStoreImmutableTip` in Setup to fetch tip at startup
- Store immutable tip in `HoardState`
- Pass immutable tip to chain sync protocol in `NodeToNode`
- Update `dev.yaml` socket paths to match nix `cardano-node` app

Open issues:

If the full node is not reachable at boot time, the application will crash. We should handle it gracefully ([issue](https://github.com/tweag/cardano-hoarding-node/issues/166)).