### PR TITLE
fix: blocks are not fetched for new headers

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -6,6 +6,7 @@ import Effectful.Concurrent (runConcurrent)
 import Effectful.FileSystem (runFileSystem)
 import Effectful.State.Static.Shared (evalState)
 import Effectful.Temporary (runTemporary)
+import Effectful.Timeout (runTimeout)
 import Prelude hiding (evalState)
 
 import Hoard.Collector (runCollectors)
@@ -38,6 +39,8 @@ import Hoard.Types.HoardState (HoardState)
 main :: IO ()
 main =
     runEff
+        . runConcurrent
+        . runTimeout
         . runChan
         . runConcNewScope
         . loadOptions
@@ -47,7 +50,6 @@ main =
         . runLog
         . runClock
         . runFileSystem
-        . runConcurrent
         . runTemporary
         . withNodeSockets
         . runNodeToClient

--- a/src/Hoard/Effects/Input.hs
+++ b/src/Hoard/Effects/Input.hs
@@ -5,15 +5,18 @@ module Hoard.Effects.Input
     , runInputConst
     , runInputChan
     , runInputList
+    , runTimedBatchedInput
     ) where
 
 import Effectful (Eff, Effect, inject, (:>))
 import Effectful.Dispatch.Dynamic (interpret_)
-import Effectful.State.Static.Shared (evalState, state)
+import Effectful.State.Static.Shared (evalState, get, modify, state)
 import Effectful.TH (makeEffect)
+import Prelude hiding (State, atomically, evalState, get, modify, state)
+
+import Effectful.Timeout (Timeout, timeout)
 import Hoard.Effects.Chan (Chan, OutChan)
 import Hoard.Effects.Chan qualified as Chan
-import Prelude hiding (evalState, modify, state)
 
 
 -- | Receive something from an arbitrary place where the origin of the
@@ -49,5 +52,30 @@ runInputList items =
             ( state $ \case
                 x :| [] -> (x, items)
                 x :| (y : ys) -> (x, y :| ys)
+            )
+        . inject
+
+
+runTimedBatchedInput
+    :: forall a es x
+     . (Input a :> es, Timeout :> es)
+    => Int
+    -- ^ Batch size
+    -> Int
+    -- ^ Timeout in microseconds
+    -> Eff (Input (NonEmpty a) : es) x
+    -> Eff es x
+runTimedBatchedInput size delay =
+    evalState @[a] []
+        . interpret_
+            ( \Input -> do
+                h <- input -- Get first item (blocking, no timeout)
+                _ <- timeout delay $
+                    replicateM_ (size - 1) do
+                        x <- input @a
+                        modify (x :)
+
+                (rest :: [a]) <- get
+                pure $ h :| reverse rest
             )
         . inject

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -4,6 +4,7 @@ import Effectful (Eff, (:>))
 import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Shared (State)
+import Effectful.Timeout (Timeout)
 import Prelude hiding (Reader, State)
 
 import Hoard.Effects.BlockRepo (BlockRepo)
@@ -66,6 +67,7 @@ runListeners
        , Reader Config :> es
        , State HoardState :> es
        , Sub :> es
+       , Timeout :> es
        )
     => Eff es ()
 runListeners = do

--- a/src/Hoard/Listeners/DiscoveredNodesListener.hs
+++ b/src/Hoard/Listeners/DiscoveredNodesListener.hs
@@ -2,11 +2,12 @@ module Hoard.Listeners.DiscoveredNodesListener (dispatchDiscoveredNodes) where
 
 import Data.Set qualified as S
 import Effectful (Eff, (:>))
+import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Shared (State)
+import Effectful.Timeout (Timeout)
 import Prelude hiding (Reader, State, gets, modify)
 
-import Effectful.Concurrent (Concurrent)
 import Hoard.Collector (bracketCollector)
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.BlockRepo (BlockRepo)
@@ -34,15 +35,16 @@ import Hoard.Types.HoardState (HoardState (..))
 dispatchDiscoveredNodes
     :: ( BlockRepo :> es
        , Chan :> es
+       , Clock :> es
        , Conc :> es
+       , Concurrent :> es
        , Log :> es
        , NodeToNode :> es
        , PeerRepo :> es
-       , Concurrent :> es
        , Pub :> es
        , Reader Config :> es
        , State HoardState :> es
-       , Clock :> es
+       , Timeout :> es
        )
     => PeersReceived
     -> Eff es ()

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -25,6 +25,7 @@ import Cardano.Api (NodeConfig)
 import Data.Aeson (FromJSON (..), withObject, (.:))
 import Data.Dynamic (Dynamic)
 import Data.Time (NominalDiffTime)
+import Effectful.Concurrent.QSem (QSem)
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo)
 import Ouroboros.Network.IOManager (IOManager)
 
@@ -78,6 +79,7 @@ data Config = Config
     , topology :: Topology
     , peerSnapshot :: PeerSnapshotFile
     , peerFailureCooldown :: NominalDiffTime
+    , blockFetchQSem :: QSem
     }
 
 

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -23,6 +23,7 @@ import Effectful
     , (:>)
     )
 import Effectful.Concurrent (Concurrent, runConcurrent)
+import Effectful.Concurrent.QSem (newQSem)
 import Effectful.Exception (try)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.Reader.Static (Reader, runReader)
@@ -116,6 +117,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
     pool <- Pool.acquire $ Pool.settings []
     nodeConfig <- runEff $ loadNodeConfig "config/preview/config.json"
     protocolInfo <- runEff $ loadProtocolInfo nodeConfig
+    blockFetchQSem <- runEff $ runConcurrent $ newQSem 1
     let dbPools = DBPools pool pool
     let serverConfig = ServerConfig {host = "localhost", port = 3000}
     let config =
@@ -129,6 +131,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , topology = Topology {peerSnapshotFile = "peer-snapshot.json"}
                 , peerSnapshot = PeerSnapshotFile {bigLedgerPools = []}
                 , peerFailureCooldown = 300
+                , blockFetchQSem
                 }
     let handles =
             Handles


### PR DESCRIPTION
Food for a future PR: make the throttling keep track of bytes in flight instead of number of running requests.

Closes https://github.com/tweag/cardano-hoarding-node/issues/172