### PR TITLE
feat: add call stack to log messages

### DIFF
--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -116,7 +116,6 @@ import Hoard.Network.Types (Connection (..))
 import Hoard.Types.Cardano (CardanoBlock, CardanoHeader, CardanoPoint, CardanoTip)
 import Hoard.Types.Environment (Env)
 import Hoard.Types.Environment qualified as Env
-import Hoard.Types.Environment qualified as Log (Severity (..))
 import Hoard.Types.HoardState (HoardState (..))
 import Hoard.Types.NodeIP (NodeIP (..))
 

--- a/test/Unit/Hoard/MonitoringSpec.hs
+++ b/test/Unit/Hoard/MonitoringSpec.hs
@@ -10,8 +10,9 @@ import Prelude hiding (evalState)
 
 import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..))
-import Hoard.Effects.Log (runLogWriter)
+import Hoard.Effects.Log (Message (..), runLogWriter)
 import Hoard.Monitoring qualified as Monitoring
+import Hoard.Types.Environment (Severity (..))
 import Hoard.Types.HoardState (HoardState (..))
 
 
@@ -20,8 +21,9 @@ spec_Monitoring = do
     describe "listener" do
         it "reports correct number of peers" do
             let logs =
-                    runPureEff
-                        . execWriter @[Text]
+                    fmap (\m -> (m.severity, m.text))
+                        . runPureEff
+                        . execWriter @[Message]
                         . runLogWriter
                         . evalState
                             ( def
@@ -29,7 +31,7 @@ spec_Monitoring = do
                                 }
                             )
                         $ Monitoring.listener Monitoring.Poll
-            logs `shouldBe` ["[INFO] Currently connected to 3 peers"]
+            logs `shouldBe` [(INFO, "Currently connected to 3 peers")]
 
 
 mkPeerIDs :: Int -> [ID Peer]


### PR DESCRIPTION
<details>
<summary>Example log statements with a simple source location included:</summary>

```text
[INFO] [Hoard.Collector.info#144] Peer skipped: PeerAddress {host = 171.224.180.189, port = 53573}
[INFO] [Hoard.Listeners.CollectorEventListener.info#17] Collector: connecting to peer 157.180.60.202
[INFO] [Hoard.Collector.info#125] Peer is already connected to: PeerAddress {host = 142.127.64.153, port = 6003}
[INFO] [Hoard.Collector.info#144] Peer skipped: PeerAddress {host = 142.127.64.153, port = 6003}
[INFO] [Hoard.Listeners.CollectorEventListener.info#15] Collector: started for 74.122.122.114
[INFO] [Hoard.Listeners.CollectorEventListener.info#17] Collector: connecting to peer 74.122.122.114
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#23] ⛓  ChainSync protocol started at 2026-01-09 10:35:47.913045105 UTC
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#23] ⛓  ChainSync protocol started at 2026-01-09 10:35:47.920580505 UTC
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Collector.info#142] ExitCase: ExitCaseException Network.Socket.connect: <socket: 1038>: does not exist (Connection refused)
[ERROR] [Hoard.Control.Exception.err#26] error: collector PeerAddress {host = 74.122.122.114, port = 42935}: Network.Socket.connect: <socket: 1038>: does not exist (Connection refused)
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#36] 🎯 ChainSync intersection found
[INFO] [Hoard.Listeners.ChainSyncEventListener.info#32] ⏪ Rollback occurred
```

</details>

We can later make `ERROR` log messages show the _whole_ call stack if necessary.