### PR TITLE
feat: make peer failure cooldown configurable

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -30,3 +30,6 @@ logging:
 
 # Maximum number of file descriptors
 max_file_descriptors: 16384
+
+# Cooldown period after a peer failure before retrying (in seconds)
+peer_failure_cooldown_seconds: 300

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -31,3 +31,6 @@ logging:
 # Maximum number of file descriptors
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384
+
+# Cooldown period after a peer failure before retrying (in seconds)
+peer_failure_cooldown_seconds: 300

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -33,3 +33,6 @@ logging:
 # Maximum number of file descriptors
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384
+
+# Cooldown period after a peer failure before retrying (in seconds)
+peer_failure_cooldown_seconds: 300

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -32,3 +32,6 @@ logging:
 # Maximum number of file descriptors (soft limit)
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384
+
+# Cooldown period after a peer failure before retrying (in seconds)
+peer_failure_cooldown_seconds: 300

--- a/src/Hoard/Effects/Environment.hs
+++ b/src/Hoard/Effects/Environment.hs
@@ -21,6 +21,7 @@ import System.FilePath (takeDirectory, (</>))
 import System.IO.Error (userError)
 import Prelude hiding (Reader, asks, runReader)
 
+import Data.Time.Clock (NominalDiffTime)
 import Hoard.Effects.Chan (Chan, InChan)
 import Hoard.Effects.Chan qualified as Chan
 import Hoard.Effects.Options (Options)
@@ -42,6 +43,7 @@ data ConfigFile = ConfigFile
     , nodeSockets :: NodeSocketsConfig
     , logging :: LoggingConfig
     , maxFileDescriptors :: Maybe Word32
+    , peerFailureCooldownSeconds :: NominalDiffTime
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake ConfigFile
@@ -243,6 +245,7 @@ loadEnv eff = withSeqEffToIO \unlift -> withIOManager \ioManager -> unlift do
                 , maxFileDescriptors = configFile.maxFileDescriptors
                 , topology
                 , peerSnapshot
+                , peerFailureCooldown = configFile.peerFailureCooldownSeconds
                 }
         env = Env {config, handles}
 

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -2,8 +2,9 @@ module Hoard.Listeners (runListeners) where
 
 import Effectful (Eff, (:>))
 import Effectful.Concurrent (Concurrent)
+import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Shared (State)
-import Prelude hiding (State)
+import Prelude hiding (Reader, State)
 
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Chan (Chan)
@@ -26,6 +27,7 @@ import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (immutableTipRefresh
 import Hoard.Listeners.NetworkEventListener (networkEventListener)
 import Hoard.Listeners.PeerSharingEventListener (peerSharingEventListener)
 import Hoard.Listeners.PeersReceivedListener (peersReceivedListener)
+import Hoard.Types.Environment (Config)
 import Hoard.Types.HoardState (HoardState)
 
 
@@ -41,6 +43,7 @@ runListeners
        , NodeToNode :> es
        , PeerRepo :> es
        , Pub :> es
+       , Reader Config :> es
        , State HoardState :> es
        , Sub :> es
        )

--- a/src/Hoard/Listeners/DiscoveredNodesListener.hs
+++ b/src/Hoard/Listeners/DiscoveredNodesListener.hs
@@ -2,6 +2,7 @@ module Hoard.Listeners.DiscoveredNodesListener (dispatchDiscoveredNodes) where
 
 import Data.Set qualified as S
 import Effectful (Eff, (:>))
+import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Shared (State)
 import Prelude hiding (Reader, State, gets, modify)
 
@@ -19,6 +20,7 @@ import Hoard.Effects.NodeToNode (NodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Effects.Pub (Pub)
 import Hoard.Network.Events (PeerSharingEvent (..), PeersReceivedData (..))
+import Hoard.Types.Environment (Config)
 import Hoard.Types.HoardState (HoardState (..))
 
 
@@ -38,6 +40,7 @@ dispatchDiscoveredNodes
        , PeerRepo :> es
        , Concurrent :> es
        , Pub :> es
+       , Reader Config :> es
        , State HoardState :> es
        , Clock :> es
        )

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -24,6 +24,7 @@ where
 import Cardano.Api (NodeConfig)
 import Data.Aeson (FromJSON (..), withObject, (.:))
 import Data.Dynamic (Dynamic)
+import Data.Time (NominalDiffTime)
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo)
 import Ouroboros.Network.IOManager (IOManager)
 
@@ -76,6 +77,7 @@ data Config = Config
     , maxFileDescriptors :: Maybe Word32
     , topology :: Topology
     , peerSnapshot :: PeerSnapshotFile
+    , peerFailureCooldown :: NominalDiffTime
     }
 
 

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -128,6 +128,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , maxFileDescriptors = Nothing
                 , topology = Topology {peerSnapshotFile = "peer-snapshot.json"}
                 , peerSnapshot = PeerSnapshotFile {bigLedgerPools = []}
+                , peerFailureCooldown = 300
                 }
     let handles =
             Handles


### PR DESCRIPTION
Closes #168 

Previously the peer failure cooldown was hardcoded to 300 seconds. This adds a `peer_failure_cooldown_seconds` field to config files, allowing operators to tune retry behavior per deployment.

The cooldown is loaded from YAML configs and threaded through the Reader Config effect to `bracketCollector` and `isPeerEligible`.