### PR TITLE
refactor: flatten event structure and split listeners

### DIFF
--- a/src/Hoard/Data/Block/Extract.hs
+++ b/src/Hoard/Data/Block/Extract.hs
@@ -10,20 +10,20 @@ import Ouroboros.Consensus.Block
 import Hoard.Data.Block (Block (..))
 import Hoard.Data.BlockHash (blockHashFromHeader)
 import Hoard.Data.PoolID (mkPoolID)
-import Hoard.Network.Events (BlockReceivedData (..))
+import Hoard.Network.Events (BlockReceived (..))
 
 
--- | Extract block data from a BlockReceivedData event. Assumes the block is
--- not in the canonical chain and has not been validated.
-extractBlockData :: BlockReceivedData -> Block
-extractBlockData dat =
+-- | Extract block data from a BlockReceived event.
+-- Assumes the block is not in the canonical chain and has not been validated.
+extractBlockData :: BlockReceived -> Block
+extractBlockData event =
     Block
-        { hash = blockHashFromHeader $ getHeader dat.block
-        , slotNumber = fromIntegral $ unSlotNo $ blockSlot $ dat.block
-        , poolId = mkPoolID dat.block
-        , blockData = dat.block
+        { hash = blockHashFromHeader $ getHeader event.block
+        , slotNumber = fromIntegral $ unSlotNo $ blockSlot $ event.block
+        , poolId = mkPoolID event.block
+        , blockData = event.block
         , validationStatus = "" -- Block has yet to be validated
         , validationReason = "" -- Block has yet to be validated
         , isCanonical = False -- Default to False until proven otherwise.
-        , firstSeen = dat.timestamp
+        , firstSeen = event.timestamp
         }

--- a/src/Hoard/Data/Header/Extract.hs
+++ b/src/Hoard/Data/Header/Extract.hs
@@ -9,15 +9,15 @@ import Ouroboros.Consensus.Block.Abstract (blockNo, blockSlot)
 
 import Hoard.Data.BlockHash (blockHashFromHeader)
 import Hoard.Data.Header (Header (..))
-import Hoard.Network.Events (HeaderReceivedData (..))
+import Hoard.Network.Events (HeaderReceived (..))
 
 
--- | Extract header data from a HeaderReceivedData event
-extractHeaderData :: HeaderReceivedData -> Header
-extractHeaderData dat =
+-- | Extract header data from a HeaderReceived event
+extractHeaderData :: HeaderReceived -> Header
+extractHeaderData event =
     Header
-        { hash = blockHashFromHeader dat.header
-        , slotNumber = unSlotNo $ blockSlot dat.header
-        , blockNumber = unBlockNo $ blockNo dat.header
-        , firstSeenAt = dat.timestamp
+        { hash = blockHashFromHeader event.header
+        , slotNumber = unSlotNo $ blockSlot event.header
+        , blockNumber = unBlockNo $ blockNo event.header
+        , firstSeenAt = event.timestamp
         }

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -18,14 +18,34 @@ import Hoard.Effects.NodeToNode (NodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo)
 import Hoard.Effects.Pub (Pub)
 import Hoard.Effects.Sub (Sub, listen)
-import Hoard.Listeners.BlockFetchEventListener (blockFetchEventListener)
-import Hoard.Listeners.ChainSyncEventListener (chainSyncEventListener)
+import Hoard.Listeners.BlockFetchEventListener
+    ( blockBatchCompletedListener
+    , blockFetchFailedListener
+    , blockFetchStartedListener
+    , blockReceivedListener
+    )
+import Hoard.Listeners.ChainSyncEventListener
+    ( chainSyncHeaderReceivedListener
+    , chainSyncIntersectionFoundListener
+    , chainSyncRollBackwardListener
+    , chainSyncRollForwardListener
+    , chainSyncStartedListener
+    )
 import Hoard.Listeners.CollectorEventListener (collectorEventListener)
 import Hoard.Listeners.DiscoveredNodesListener (dispatchDiscoveredNodes)
 import Hoard.Listeners.HeaderReceivedListener (headerReceivedListener)
 import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (immutableTipRefreshTriggeredListener)
-import Hoard.Listeners.NetworkEventListener (networkEventListener)
-import Hoard.Listeners.PeerSharingEventListener (peerSharingEventListener)
+import Hoard.Listeners.NetworkEventListener
+    ( connectionEstablishedListener
+    , connectionLostListener
+    , handshakeCompletedListener
+    , protocolErrorListener
+    )
+import Hoard.Listeners.PeerSharingEventListener
+    ( peerSharingFailedListener
+    , peerSharingStartedListener
+    , peersReceivedLogListener
+    )
 import Hoard.Listeners.PeersReceivedListener (peersReceivedListener)
 import Hoard.Types.Environment (Config)
 import Hoard.Types.HoardState (HoardState)
@@ -52,10 +72,22 @@ runListeners = do
     _ <- Conc.fork $ listen headerReceivedListener
     _ <- Conc.fork $ listen peersReceivedListener
     _ <- Conc.fork $ listen dispatchDiscoveredNodes
-    _ <- Conc.fork $ listen networkEventListener
-    _ <- Conc.fork $ listen peerSharingEventListener
-    _ <- Conc.fork $ listen chainSyncEventListener
-    _ <- Conc.fork $ listen blockFetchEventListener
+    _ <- Conc.fork $ listen connectionEstablishedListener
+    _ <- Conc.fork $ listen connectionLostListener
+    _ <- Conc.fork $ listen handshakeCompletedListener
+    _ <- Conc.fork $ listen protocolErrorListener
+    _ <- Conc.fork $ listen peerSharingStartedListener
+    _ <- Conc.fork $ listen peersReceivedLogListener
+    _ <- Conc.fork $ listen peerSharingFailedListener
+    _ <- Conc.fork $ listen chainSyncHeaderReceivedListener
+    _ <- Conc.fork $ listen chainSyncStartedListener
+    _ <- Conc.fork $ listen chainSyncRollBackwardListener
+    _ <- Conc.fork $ listen chainSyncRollForwardListener
+    _ <- Conc.fork $ listen chainSyncIntersectionFoundListener
+    _ <- Conc.fork $ listen blockFetchStartedListener
+    _ <- Conc.fork $ listen blockReceivedListener
+    _ <- Conc.fork $ listen blockFetchFailedListener
+    _ <- Conc.fork $ listen blockBatchCompletedListener
     _ <- Conc.fork $ listen collectorEventListener
     _ <- Conc.fork $ listen immutableTipRefreshTriggeredListener
     pure ()

--- a/src/Hoard/Listeners/NetworkEventListener.hs
+++ b/src/Hoard/Listeners/NetworkEventListener.hs
@@ -1,26 +1,53 @@
-module Hoard.Listeners.NetworkEventListener (networkEventListener) where
+module Hoard.Listeners.NetworkEventListener
+    ( connectionEstablishedListener
+    , connectionLostListener
+    , handshakeCompletedListener
+    , protocolErrorListener
+    ) where
 
 import Effectful (Eff, (:>))
 
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Network.Events
-    ( ConnectionEstablishedData (..)
-    , ConnectionLostData (..)
-    , HandshakeCompletedData (..)
-    , NetworkEvent (..)
-    , ProtocolErrorData (..)
+    ( ConnectionEstablished (..)
+    , ConnectionLost (..)
+    , HandshakeCompleted (..)
+    , ProtocolError (..)
     )
 
 
--- | Listener that logs network events
-networkEventListener :: (Log :> es) => NetworkEvent -> Eff es ()
-networkEventListener = \case
-    ConnectionEstablished dat -> do
-        Log.info $ "🔗 Connection established with peer at " <> show dat.timestamp
-    ConnectionLost dat -> do
-        Log.info $ "💔 Connection lost: " <> dat.reason <> " at " <> show dat.timestamp
-    HandshakeCompleted dat -> do
-        Log.info $ "🤝 Handshake completed with version " <> show dat.version
-    ProtocolError dat -> do
-        Log.warn $ "❌ Protocol error: " <> dat.errorMessage
+-- | Listener that logs connection established events
+connectionEstablishedListener
+    :: (Log :> es)
+    => ConnectionEstablished
+    -> Eff es ()
+connectionEstablishedListener event = do
+    Log.info $ "🔗 Connection established with peer at " <> show event.timestamp
+
+
+-- | Listener that logs connection lost events
+connectionLostListener
+    :: (Log :> es)
+    => ConnectionLost
+    -> Eff es ()
+connectionLostListener event = do
+    Log.info $ "💔 Connection lost: " <> event.reason <> " at " <> show event.timestamp
+
+
+-- | Listener that logs handshake completed events
+handshakeCompletedListener
+    :: (Log :> es)
+    => HandshakeCompleted
+    -> Eff es ()
+handshakeCompletedListener event = do
+    Log.info $ "🤝 Handshake completed with version " <> show event.version
+
+
+-- | Listener that logs protocol error events
+protocolErrorListener
+    :: (Log :> es)
+    => ProtocolError
+    -> Eff es ()
+protocolErrorListener event = do
+    Log.warn $ "❌ Protocol error: " <> event.errorMessage

--- a/src/Hoard/Listeners/PeerSharingEventListener.hs
+++ b/src/Hoard/Listeners/PeerSharingEventListener.hs
@@ -1,4 +1,8 @@
-module Hoard.Listeners.PeerSharingEventListener (peerSharingEventListener) where
+module Hoard.Listeners.PeerSharingEventListener
+    ( peerSharingStartedListener
+    , peersReceivedLogListener
+    , peerSharingFailedListener
+    ) where
 
 import Effectful (Eff, (:>))
 
@@ -6,21 +10,27 @@ import Hoard.Data.Peer (PeerAddress (..))
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Network.Events
-    ( PeerSharingEvent (..)
-    , PeerSharingFailedData (..)
-    , PeerSharingStartedData (..)
-    , PeersReceivedData (..)
+    ( PeerSharingFailed (..)
+    , PeerSharingStarted (..)
+    , PeersReceived (..)
     )
 
 
--- | Listener that logs peer sharing events
-peerSharingEventListener :: (Log :> es) => PeerSharingEvent -> Eff es ()
-peerSharingEventListener = \case
-    PeerSharingStarted dat -> do
-        Log.info $ "🔍 PeerSharing protocol started at " <> show dat.timestamp
-    PeersReceived dat -> do
-        Log.info $ "📡 Received " <> show (length dat.peerAddresses) <> " peer addresses from remote peer:"
-        forM_ dat.peerAddresses $ \addr ->
-            Log.debug $ "   - " <> show addr.host <> ":" <> show addr.port
-    PeerSharingFailed dat -> do
-        Log.warn $ "❌ PeerSharing failed: " <> dat.errorMessage
+-- | Listener that logs PeerSharing started events
+peerSharingStartedListener :: (Log :> es) => PeerSharingStarted -> Eff es ()
+peerSharingStartedListener event = do
+    Log.info $ "🔍 PeerSharing protocol started at " <> show event.timestamp
+
+
+-- | Listener that logs peer addresses received events
+peersReceivedLogListener :: (Log :> es) => PeersReceived -> Eff es ()
+peersReceivedLogListener event = do
+    Log.info $ "📡 Received " <> show (length event.peerAddresses) <> " peer addresses from remote peer:"
+    forM_ event.peerAddresses $ \addr ->
+        Log.debug $ "   - " <> show addr.host <> ":" <> show addr.port
+
+
+-- | Listener that logs PeerSharing failed events
+peerSharingFailedListener :: (Log :> es) => PeerSharingFailed -> Eff es ()
+peerSharingFailedListener event = do
+    Log.warn $ "❌ PeerSharing failed: " <> event.errorMessage

--- a/src/Hoard/Listeners/PeersReceivedListener.hs
+++ b/src/Hoard/Listeners/PeersReceivedListener.hs
@@ -4,14 +4,13 @@ import Effectful (Eff, (:>))
 
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
-import Hoard.Network.Events (PeerSharingEvent (..), PeersReceivedData (..))
+import Hoard.Network.Events (PeersReceived (..))
 
 
 -- | Handler that persists discovered peers to the database
 --
 -- Processes PeersReceived events and upserts the peer information into
 -- the database.
-peersReceivedListener :: (PeerRepo :> es) => PeerSharingEvent -> Eff es ()
-peersReceivedListener = \case
-    PeersReceived dat -> void $ upsertPeers dat.peerAddresses dat.peer.address dat.timestamp
-    _ -> pure () -- Ignore other PeerSharing events
+peersReceivedListener :: (PeerRepo :> es) => PeersReceived -> Eff es ()
+peersReceivedListener event =
+    void $ upsertPeers event.peerAddresses event.peer.address event.timestamp


### PR DESCRIPTION
- Remove Event wrapper types (`NetworkEvent`, `ChainSyncEvent`, etc.)
- Remove Data suffix from event types (`HeaderReceivedData` -> HeaderReceived)
- Split monolithic event listeners into individual listeners per event type
- Update all event publishers and subscribers to use new flat structure
- Simplify event handling by removing unnecessary nesting