### PR TITLE
feat: separate log filtering from log running

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -20,6 +20,7 @@ import Hoard.Effects.DBWrite (runDBWrite)
 import Hoard.Effects.Environment (loadEnv, runConfigReader, runHandlesReader)
 import Hoard.Effects.HeaderRepo (runHeaderRepo)
 import Hoard.Effects.Log (runLog)
+import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.NodeToClient (runNodeToClient)
 import Hoard.Effects.NodeToNode (runNodeToNode)
 import Hoard.Effects.Options (loadOptions)
@@ -45,6 +46,7 @@ main =
         . runConfigReader
         . runHandlesReader
         . runLog
+        . Log.filterWithLogConfig
         . runClock
         . runFileSystem
         . runConcurrent

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -44,6 +44,7 @@ library
       Hoard.Effects.HeaderRepo
       Hoard.Effects.Input
       Hoard.Effects.Log
+      Hoard.Effects.Log.Labeled
       Hoard.Effects.NodeToClient
       Hoard.Effects.NodeToNode
       Hoard.Effects.NodeToNode.Codecs
@@ -268,6 +269,7 @@ test-suite hoard-test
       Integration.Hoard.SchemaSpec
       Unit.Hoard.Data.BlockSpec
       Unit.Hoard.Data.PeerSpec
+      Unit.Hoard.Effects.Log.LabeledSpec
       Unit.Hoard.Listeners.HeaderReceivedListenerSpec
       Unit.Hoard.MonitoringSpec
       Paths_hoard

--- a/src/Hoard/Effects/Log/Labeled.hs
+++ b/src/Hoard/Effects/Log/Labeled.hs
@@ -1,0 +1,34 @@
+module Hoard.Effects.Log.Labeled
+    ( LabeledLogger (..)
+    , LogFn
+    , labeled
+    ) where
+
+import Effectful (Eff, (:>))
+import Hoard.Effects.Log (Log)
+import Hoard.Effects.Log qualified as Log
+
+
+labeled :: (HasCallStack, Log :> es) => Text -> LabeledLogger (Eff es)
+labeled =
+    withFrozenCallStack $ \label ->
+        let withLabel f s = f (label <> s)
+        in  LabeledLogger
+                { debug = withLabel Log.debug
+                , info = withLabel Log.info
+                , warn = withLabel Log.warn
+                , err = withLabel Log.err
+                , appendLabel = \l -> labeled $ label <> l
+                }
+
+
+data LabeledLogger m = LabeledLogger
+    { debug :: LogFn m
+    , info :: LogFn m
+    , warn :: LogFn m
+    , err :: LogFn m
+    , appendLabel :: Text -> LabeledLogger m
+    }
+
+
+type LogFn m = Text -> m ()

--- a/test/Unit/Hoard/Effects/Log/LabeledSpec.hs
+++ b/test/Unit/Hoard/Effects/Log/LabeledSpec.hs
@@ -1,0 +1,32 @@
+module Unit.Hoard.Effects.Log.LabeledSpec (spec_LabeledBomber) where
+
+import Effectful (runPureEff)
+import Effectful.Writer.Static.Shared (execWriter)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.Log.Labeled (LabeledLogger (..))
+import Hoard.Effects.Log.Labeled qualified as Labeled
+
+
+spec_LabeledBomber :: Spec
+spec_LabeledBomber = do
+    it "prepends a label to the logged message" do
+        let (msgs :: [Text]) = runLog do
+                Log.debug "foo"
+                let logger = Labeled.labeled "foo: "
+                logger.debug "bar"
+
+        msgs `shouldBe` ["foo", "foo: bar"]
+
+    describe "appendLabel" do
+        it "appends a label to the current label" do
+            let (msgs :: [Text]) = runLog do
+                    let logger = Labeled.labeled "foo: "
+                    logger.debug "bar"
+                    let subLogger = logger.appendLabel "quack: "
+                    subLogger.debug "qux"
+
+            msgs `shouldBe` ["foo: bar", "foo: quack: qux"]
+  where
+    runLog = fmap Log.text . runPureEff . execWriter @[Log.Message] . Log.runLogWriter


### PR DESCRIPTION
- Add `filterLog` to filter logged messages on arbitrary properties of the logged messages.
- Add `filterWithLogConfig` to filter with `LogConfig` from `Hoard.Types.Environment`.
- Add `Hoard.Effects.Log.Labeled` to more easily emit log messages with a prefixed label.