### PR TITLE
refactor: remove log filtering

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -25,9 +25,6 @@ database:
     aging_timeout_seconds: 600
     idleness_timeout_seconds: 300
 
-logging:
-  minimum_severity: DEBUG
-
 # Maximum number of file descriptors
 max_file_descriptors: 16384
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -25,9 +25,6 @@ database:
     aging_timeout_seconds: 1800
     idleness_timeout_seconds: 600
 
-logging:
-  minimum_severity: DEBUG
-
 # Maximum number of file descriptors
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -27,9 +27,6 @@ database:
     aging_timeout_seconds: 3600
     idleness_timeout_seconds: 1200
 
-logging:
-  minimum_severity: INFO
-
 # Maximum number of file descriptors
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -26,9 +26,6 @@ database:
     aging_timeout_seconds: 1800
     idleness_timeout_seconds: 600
 
-logging:
-  minimum_severity: INFO
-
 # Maximum number of file descriptors (soft limit)
 # Increase this to support many concurrent peer connections
 max_file_descriptors: 16384

--- a/src/Hoard/Effects/Log.hs
+++ b/src/Hoard/Effects/Log.hs
@@ -85,9 +85,8 @@ runLog action = do
     -- Fork worker thread that reads from channel and writes to handle
     Conc.fork_ $ forever $ do
         msg <- Chan.readChan outChan
-        liftIO $ when (msg.severity >= config.minimumSeverity) $ do
-            T.hPutStrLn config.output $ formatMessage msg
-            hFlush stdout
+        liftIO $ T.hPutStrLn config.output $ formatMessage msg
+        liftIO $ hFlush stdout
 
     -- Interpret Log effect to write messages to channel
     interpret_ (\(LogMsg msg) -> Chan.writeChan inChan msg) action

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -44,9 +44,8 @@ data ServerConfig = ServerConfig
     deriving (FromJSON) via QuietSnake ServerConfig
 
 
-data LogConfig = LogConfig
-    { minimumSeverity :: Severity
-    , output :: Handle
+newtype LogConfig = LogConfig
+    { output :: Handle
     }
 
 
@@ -62,8 +61,7 @@ data Severity
 defaultLogConfig :: LogConfig
 defaultLogConfig =
     LogConfig
-        { minimumSeverity = minBound
-        , output = stdout
+        { output = stdout
         }
 
 


### PR DESCRIPTION
Leave log filtering to external tools like `grep`.