### PR TITLE
chore: treat GHC warnings as errors in Nix builds

### DIFF
--- a/nix/project.nix
+++ b/nix/project.nix
@@ -34,6 +34,9 @@ pkgs.haskell-nix.cabalProject' {
 
         # Configure hoard package
         hoard = {
+          # Treat warnings as errors in Nix builds (CI), but not in local dev
+          ghcOptions = [ "-Werror" ];
+
           # Configure test suite component
           components.tests.hoard-test = {
             # Add build-time tools needed for tests


### PR DESCRIPTION
Adds `-Werror` to Nix builds (CI) while keeping local cabal builds flexible for development. This ensures warnings like unused imports fail in CI.