### PR TITLE
revert: refactor: use separate thread scopes for each collector

### DIFF
--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -147,7 +147,7 @@ bracketCollector peer = do
                         Nothing ->
                             Log.debug $ "Peer skipped: " <> show peer.address
                 )
-                (traverse_ $ Conc.subScoped . runCollector)
+                (traverse_ runCollector)
     pure ()
 
 


### PR DESCRIPTION
Reverts tweag/cardano-hoarding-node#186

`Ki` threads already kill their children when exiting, so using a sub-scope for each collector is redundant.