### PR TITLE
feat: track block fetch bytes in flight

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -46,7 +46,9 @@ cardano_protocols:
   block_fetch:
     batch_size: 10
     batch_timeout_microseconds: 1000000 # 1 second
-    maximum_ingress_queue: 393216 # 384 KiB
+    maximum_ingress_queue: 589824 # 576 KiB
+    low_watermark: 196608 # 192 KiB
+    high_watermark: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -47,7 +47,9 @@ cardano_protocols:
   block_fetch:
     batch_size: 10
     batch_timeout_microseconds: 1000000 # 1 second
-    maximum_ingress_queue: 393216 # 384 KiB
+    maximum_ingress_queue: 589824 # 576 KiB
+    low_watermark: 196608 # 192 KiB
+    high_watermark: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -49,7 +49,9 @@ cardano_protocols:
   block_fetch:
     batch_size: 10
     batch_timeout_microseconds: 1000000 # 1 second
-    maximum_ingress_queue: 393216 # 384 KiB
+    maximum_ingress_queue: 589824 # 576 KiB
+    low_watermark: 196608 # 192 KiB
+    high_watermark: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -48,7 +48,9 @@ cardano_protocols:
   block_fetch:
     batch_size: 10
     batch_timeout_microseconds: 1000000 # 1 second
-    maximum_ingress_queue: 393216 # 384 KiB
+    maximum_ingress_queue: 589824 # 576 KiB
+    low_watermark: 196608 # 192 KiB
+    high_watermark: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -21,6 +21,7 @@ library
       Hoard.BlockFetch.Events
       Hoard.BlockFetch.Listeners
       Hoard.BlockFetch.NodeToNode
+      Hoard.BlockFetch.State
       Hoard.Bootstrap
       Hoard.ChainSync
       Hoard.ChainSync.Config

--- a/nix/cardano-node.nix
+++ b/nix/cardano-node.nix
@@ -142,7 +142,8 @@ let
           --topology ${topologyPath} \
           --database-path ${dbPath} \
           --socket-path ${socketPath} \
-          --tracer-socket-path-accept /tmp/cardano-tracer.sock
+          --tracer-socket-path-accept /tmp/cardano-tracer.sock \
+          "$@"
       ''}";
     };
 

--- a/src/Hoard/BlockFetch/Config.hs
+++ b/src/Hoard/BlockFetch/Config.hs
@@ -19,6 +19,10 @@ data Config = Config
     -- ^ Timeout for batching block fetch requests
     , maximumIngressQueue :: Int
     -- ^ Max bytes queued in ingress queue
+    , lowWatermark :: Int
+    -- ^ Watermark for number of bytes in flight before BlockFetch will resume issuing block requests.
+    , highWatermark :: Int
+    -- ^ Watermark for number of bytes in flight after which BlockFetch will halt issuing block requests.
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake Config
@@ -29,7 +33,9 @@ instance Default Config where
         Config
             { batchSize = 10
             , batchTimeoutMicroseconds = 10_000_000 -- 10 seconds
-            , maximumIngressQueue = 393216 -- 384 KiB
+            , maximumIngressQueue = 589824 -- 576 KiB
+            , lowWatermark = 196608 -- 192KiB
+            , highWatermark = 393216 -- 384KiB
             }
 
 

--- a/src/Hoard/BlockFetch/NodeToNode.hs
+++ b/src/Hoard/BlockFetch/NodeToNode.hs
@@ -1,8 +1,10 @@
 module Hoard.BlockFetch.NodeToNode (miniProtocol, client) where
 
+import Control.Tracer (nullTracer)
 import Data.List (maximum, minimum)
 import Effectful (Eff, (:>))
 import Effectful.Concurrent (Concurrent)
+import Effectful.State.Static.Shared (State)
 import Effectful.Timeout (Timeout)
 import Network.Mux (StartOnDemandOrEagerly (..))
 import Network.TypedProtocol.Peer.Client qualified as Peer
@@ -30,6 +32,7 @@ import Hoard.BlockFetch.Events
     , BlockFetchStarted (..)
     , BlockReceived (..)
     )
+import Hoard.BlockFetch.State (Status, registerRequest, unregisterRequest, waitUntilReadyToFetch)
 import Hoard.Control.Exception (withExceptionLogging)
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.Chan (Chan, readChanBatched)
@@ -52,6 +55,7 @@ miniProtocol
        , Log :> es
        , Pub :> es
        , Sub :> es
+       , State Status :> es
        , Timeout :> es
        )
     => (forall x. Eff es x -> IO x)
@@ -67,11 +71,11 @@ miniProtocol unlift conf codecs peer =
         , miniProtocolRun = InitiatorProtocolOnly $ mkMiniProtocolCbFromPeer $ \_ ->
             let codec = cBlockFetchCodec codecs
                 blockFetchClient = client unlift conf peer
-                tracer = (("[BlockFetch tracer] " <>) . show) >$< Log.asTracer unlift Log.DEBUG
+                -- tracer = (("[BlockFetch tracer] " <>) . show) >$< Log.asTracer unlift Log.DEBUG
                 wrappedPeer = Peer.Effect $ unlift $ withExceptionLogging "BlockFetch" $ do
                     Log.debug "BlockFetch protocol started"
                     pure $ blockFetchClientPeer blockFetchClient
-            in  (tracer, codec, wrappedPeer)
+            in  (nullTracer, codec, wrappedPeer)
         }
 
 
@@ -85,6 +89,7 @@ client
        , Log :> es
        , Pub :> es
        , Sub :> es
+       , State Status :> es
        , Timeout :> es
        )
     => (forall x. Eff es x -> IO x)
@@ -92,12 +97,9 @@ client
     -> Peer
     -> BlockFetch.BlockFetchClient CardanoBlock CardanoPoint IO ()
 client unlift cfg peer =
-    BlockFetch.BlockFetchClient $ unlift $ withNamespace "BlockFetchClient" $ do
+    BlockFetch.BlockFetchClient $ unlift $ withNamespace ("BlockFetchClient" <> show peer.address) do
         timestamp <- Clock.currentTime
         publish $ BlockFetchStarted {peer, timestamp}
-        Log.debug "BlockFetch: Published BlockFetchStarted event"
-        Log.debug "BlockFetch: Starting client, awaiting block download requests"
-
         (inChan, outChan) <- Chan.newChan
 
         Conc.fork_ $ listen \(req :: BlockFetchRequest) ->
@@ -106,9 +108,10 @@ client unlift cfg peer =
         awaitMessage outChan
   where
     awaitMessage outChan = do
+        waitUntilReadyToFetch
         reqs <- readChanBatched cfg.batchTimeoutMicroseconds cfg.batchSize outChan
-
-        Log.info $ "BlockFetch: Received " <> show (length reqs) <> " block fetch requests"
+        registerRequest cfg ((.header) <$> toList reqs)
+        Log.info $ "Received " <> show (length reqs) <> " requests"
         let points = headerPoint . (.header) <$> reqs
             start = minimum points
             end = maximum points
@@ -121,12 +124,13 @@ client unlift cfg peer =
     handleResponse reqs =
         BlockFetch.BlockFetchResponse
             { handleStartBatch =
-                pure $ blockReceiver 0
-            , handleNoBlocks = unlift $ do
-                Log.info "BlockFetch: No blocks returned by peer"
+                pure $ blockReceiver reqs 0
+            , handleNoBlocks = unlift do
+                unregisterRequest cfg $ (.header) <$> toList reqs
+                Log.info "No blocks returned by peer"
                 timestamp <- Clock.currentTime
                 for_ reqs \req ->
-                    publish $
+                    publish
                         BlockFetchFailed
                             { peer
                             , timestamp
@@ -135,9 +139,9 @@ client unlift cfg peer =
                             }
             }
 
-    blockReceiver blockCount =
+    blockReceiver reqs blockCount =
         BlockFetch.BlockFetchReceiver
-            { handleBlock = \block -> unlift $ do
+            { handleBlock = \block -> unlift do
                 timestamp <- Clock.currentTime
                 let event =
                         BlockReceived
@@ -146,11 +150,12 @@ client unlift cfg peer =
                             , block
                             }
                 publish event
-                pure $ blockReceiver $ blockCount + 1
-            , handleBatchDone = unlift $ do
-                Log.info $ "BlockFetch: Batch done (fetched " <> show blockCount <> " blocks)"
+                pure $ blockReceiver reqs $ blockCount + 1
+            , handleBatchDone = unlift do
+                Log.info $ "Batch done (received " <> show blockCount <> " blocks)"
+                unregisterRequest cfg $ (.header) <$> toList reqs
                 timestamp <- Clock.currentTime
-                publish $
+                publish
                     BlockBatchCompleted
                         { peer
                         , timestamp

--- a/src/Hoard/BlockFetch/State.hs
+++ b/src/Hoard/BlockFetch/State.hs
@@ -1,0 +1,88 @@
+module Hoard.BlockFetch.State
+    ( Status (..)
+    , BytesInFlight (..)
+    , mkStatus
+    , waitUntilReadyToFetch
+    , registerRequest
+    , unregisterRequest
+    ) where
+
+import Effectful (Eff, (:>))
+import Effectful.Concurrent.MVar (Concurrent, newMVar, readMVar, tryPutMVar, tryTakeMVar)
+import Effectful.State.Static.Shared (State, gets, stateM)
+import Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common (estimateHfcBlockSize)
+import Prelude hiding (State, gets, newMVar, readMVar, tryPutMVar, tryTakeMVar)
+
+import Hoard.BlockFetch.Config (Config (..))
+import Hoard.Effects.Log (Log)
+import Hoard.Effects.Log qualified as Log
+import Hoard.Types.Cardano (CardanoHeader)
+
+
+data Status = Status
+    { stateVar :: MVar ()
+    -- ^ Signals whether this collector is ready to issue block fetch requests
+    -- to its connected peer.
+    , bytesInFlight :: BytesInFlight
+    }
+
+
+mkStatus :: (Concurrent :> es) => Eff es Status
+mkStatus = do
+    stateVar <- newMVar ()
+    pure
+        Status
+            { stateVar
+            , bytesInFlight = 0
+            }
+
+
+newtype BytesInFlight = BytesInFlight Int
+    deriving (Eq, Ord, Show)
+    deriving (Num) via Int
+
+
+waitUntilReadyToFetch :: (Concurrent :> es, State Status :> es) => Eff es ()
+waitUntilReadyToFetch = do
+    _ <- readMVar =<< gets (.stateVar)
+    pure ()
+
+
+-- | Registers a new batch of blocks being fetched with BlockFetch. Calculates
+-- the estimated total size of the fetched blocks and adds it to the total of
+-- bytes in flight. If the new total of bytes in flight exceed the high
+-- watermark, the block fetch status is set to "Busy", awaiting the bytes in
+-- flight count to drop below the low watermark.
+registerRequest :: (Log :> es, Concurrent :> es, State Status :> es) => Config -> [CardanoHeader] -> Eff es ()
+registerRequest config headers = do
+    stateM \s ->
+        let
+            newBytes = fromIntegral . sum $ estimateHfcBlockSize <$> toList headers
+            bytesInFlight = s.bytesInFlight + newBytes
+        in
+            do
+                when (coerce bytesInFlight > config.highWatermark) $ do
+                    x <- tryTakeMVar s.stateVar
+                    when (isJust x) $
+                        Log.debug "Entering busy state"
+                pure ((), s {bytesInFlight})
+
+
+-- | Removes the passed batch of blocks being fetched from the total count of
+-- bytes in flight. Calculates the estimated total size of the fetched blocks
+-- and removes it from the total of bytes in flight. If the new total of bytes
+-- in flight is lower than the low watermark, the block fetch status is set to
+-- "Ready", and block fetching may continue if it was previously "Busy".
+unregisterRequest :: (Log :> es, Concurrent :> es, State Status :> es) => Config -> [CardanoHeader] -> Eff es ()
+unregisterRequest config headers = do
+    stateM \s ->
+        let
+            newBytes = fromIntegral . sum $ estimateHfcBlockSize <$> toList headers
+            bytesInFlight = s.bytesInFlight - newBytes
+        in
+            do
+                when (coerce bytesInFlight < config.lowWatermark) $ do
+                    wasBusy <- tryPutMVar s.stateVar ()
+                    when wasBusy $
+                        Log.debug "Entering ready state"
+                pure ((), s {bytesInFlight})

--- a/src/Hoard/Data/Peer.hs
+++ b/src/Hoard/Data/Peer.hs
@@ -7,13 +7,14 @@ module Hoard.Data.Peer
 where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.IP qualified as IP
 import Data.Time (UTCTime)
 import Network.Socket (SockAddr)
+import Text.Show qualified as Show
+import Prelude hiding (id)
 
-import Data.IP qualified as IP
 import Hoard.Data.ID (ID)
 import Hoard.Types.NodeIP (NodeIP (..))
-import Prelude hiding (id)
 
 
 -- | Represents a peer in the P2P network
@@ -35,8 +36,13 @@ data PeerAddress = PeerAddress
     { host :: NodeIP
     , port :: Int
     }
-    deriving stock (Eq, Ord, Generic, Show)
+    deriving stock (Eq, Ord, Generic)
     deriving (FromJSON, ToJSON)
+
+
+instance Show PeerAddress where
+    show (PeerAddress {host, port}) =
+        show host <> ":" <> show port
 
 
 -- | Convert a SockAddr to a PeerAddress


### PR DESCRIPTION
Track bytes in flight for current block fetch requests on a per-node basis and limit the bytes in flight accordingly. This strategy is adopted from the `cardano-node`'s own implementation of watermarks and in-flight byte tracking for `BlockFetch`.

Depends on #200