### PR TITLE
refactor: move BlockFetch config to Hoard.BlockFetch

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -37,20 +37,24 @@ peer_failure_cooldown_seconds: 300
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:
-    request_interval_microseconds: 3600000000  # 1 hour
+    request_interval_microseconds: 3600000000 # 1 hour
     request_amount: 100
     maximum_ingress_queue: 1000
   keep_alive:
-    interval_microseconds: 10000000  # 10 seconds
+    interval_microseconds: 10000000 # 10 seconds
     maximum_ingress_queue: 1000
   block_fetch:
     batch_size: 10
-    batch_timeout_microseconds: 1000000  # 1 second
-    maximum_ingress_queue: 393216  # 384 KiB
+    batch_timeout_microseconds: 1000000 # 1 second
+    maximum_ingress_queue: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:
     maximum_ingress_queue: 10
+
+cardano_protocol_handles:
+  block_fetch:
+    max_concurrent_fetches: 1
 
 # Monitoring configuration
 monitoring:

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -38,20 +38,24 @@ peer_failure_cooldown_seconds: 300
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:
-    request_interval_microseconds: 3600000000  # 1 hour
+    request_interval_microseconds: 3600000000 # 1 hour
     request_amount: 100
     maximum_ingress_queue: 1000
   keep_alive:
-    interval_microseconds: 10000000  # 10 seconds
+    interval_microseconds: 10000000 # 10 seconds
     maximum_ingress_queue: 1000
   block_fetch:
     batch_size: 10
-    batch_timeout_microseconds: 1000000  # 1 second
-    maximum_ingress_queue: 393216  # 384 KiB
+    batch_timeout_microseconds: 1000000 # 1 second
+    maximum_ingress_queue: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:
     maximum_ingress_queue: 10
+
+cardano_protocol_handles:
+  block_fetch:
+    max_concurrent_fetches: 1
 
 # Monitoring configuration
 monitoring:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -40,20 +40,24 @@ peer_failure_cooldown_seconds: 300
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:
-    request_interval_microseconds: 3600000000  # 1 hour
+    request_interval_microseconds: 3600000000 # 1 hour
     request_amount: 100
     maximum_ingress_queue: 1000
   keep_alive:
-    interval_microseconds: 10000000  # 10 seconds
+    interval_microseconds: 10000000 # 10 seconds
     maximum_ingress_queue: 1000
   block_fetch:
     batch_size: 10
-    batch_timeout_microseconds: 1000000  # 1 second
-    maximum_ingress_queue: 393216  # 384 KiB
+    batch_timeout_microseconds: 1000000 # 1 second
+    maximum_ingress_queue: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:
     maximum_ingress_queue: 10
+
+cardano_protocol_handles:
+  block_fetch:
+    max_concurrent_fetches: 1
 
 # Monitoring configuration
 monitoring:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -39,20 +39,24 @@ peer_failure_cooldown_seconds: 300
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:
-    request_interval_microseconds: 3600000000  # 1 hour
+    request_interval_microseconds: 3600000000 # 1 hour
     request_amount: 100
     maximum_ingress_queue: 1000
   keep_alive:
-    interval_microseconds: 10000000  # 10 seconds
+    interval_microseconds: 10000000 # 10 seconds
     maximum_ingress_queue: 1000
   block_fetch:
     batch_size: 10
-    batch_timeout_microseconds: 1000000  # 1 second
-    maximum_ingress_queue: 393216  # 384 KiB
+    batch_timeout_microseconds: 1000000 # 1 second
+    maximum_ingress_queue: 393216 # 384 KiB
   chain_sync:
     maximum_ingress_queue: 1200
   tx_submission:
     maximum_ingress_queue: 10
+
+cardano_protocol_handles:
+  block_fetch:
+    max_concurrent_fetches: 1
 
 # Monitoring configuration
 monitoring:

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -17,6 +17,7 @@ library
   exposed-modules:
       Hoard.API
       Hoard.BlockFetch
+      Hoard.BlockFetch.Config
       Hoard.BlockFetch.Events
       Hoard.BlockFetch.Listeners
       Hoard.BlockFetch.NodeToNode

--- a/src/Hoard/BlockFetch/Config.hs
+++ b/src/Hoard/BlockFetch/Config.hs
@@ -1,0 +1,51 @@
+module Hoard.BlockFetch.Config
+    ( Config (..)
+    , Handles (..)
+    , HandlesConfig (..)
+    , loadHandles
+    ) where
+
+import Data.Aeson (FromJSON (..))
+import Data.Default (Default (..))
+import Effectful (Eff, (:>))
+import Effectful.Concurrent.QSem (Concurrent, QSem, newQSem)
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+
+data Config = Config
+    { batchSize :: Int
+    -- ^ Number of block fetch requests to batch
+    , batchTimeoutMicroseconds :: Int
+    -- ^ Timeout for batching block fetch requests
+    , maximumIngressQueue :: Int
+    -- ^ Max bytes queued in ingress queue
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake Config
+
+
+instance Default Config where
+    def =
+        Config
+            { batchSize = 10
+            , batchTimeoutMicroseconds = 10_000_000 -- 10 seconds
+            , maximumIngressQueue = 393216 -- 384 KiB
+            }
+
+
+data HandlesConfig = HandlesConfig
+    { maxConcurrentFetches :: Int
+    }
+    deriving (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake HandlesConfig
+
+
+data Handles = Handles
+    { qSem :: QSem
+    }
+
+
+loadHandles :: (Concurrent :> es) => HandlesConfig -> Eff es Handles
+loadHandles conf = do
+    qSem <- newQSem conf.maxConcurrentFetches
+    pure Handles {qSem}

--- a/src/Hoard/Collectors/Listeners.hs
+++ b/src/Hoard/Collectors/Listeners.hs
@@ -14,6 +14,7 @@ import Effectful.State.Static.Shared (State, modify, state, stateM)
 import Effectful.Timeout (Timeout)
 import Prelude hiding (Reader, State, asks, modify, state)
 
+import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.BlockFetch.Events (BlockFetchRequest (..), BlockReceived (..))
 import Hoard.ChainSync.Events (HeaderReceived (..))
 import Hoard.Collectors.Events (CollectorEvent (..))
@@ -38,7 +39,7 @@ import Hoard.Effects.Output (Output, output, runOutputChan)
 import Hoard.Effects.PeerRepo (PeerRepo, updatePeerFailure, upsertPeers)
 import Hoard.Effects.Publishing (Pub, publish)
 import Hoard.Network.Events (PeersReceived (..))
-import Hoard.Types.Environment (BlockFetchConfig (..), CardanoProtocolsConfig (..), Config (..))
+import Hoard.Types.Environment (CardanoProtocolsConfig (..), Config (..))
 import Hoard.Types.HoardState (HoardState (..))
 
 


### PR DESCRIPTION
Introduces the concept of `CardanoProtocolHandles`, where each module can remain responsible for their own handles like `BlockFetch`'s `QSem`. Currently, only `BlockFetch` has a dedicated handle.