### PR TITLE
refactor: remove BlocksBeingFetched state

### DIFF
--- a/src/Hoard/BlockFetch.hs
+++ b/src/Hoard/BlockFetch.hs
@@ -9,7 +9,7 @@ import Hoard.Collectors.State (BlocksBeingFetched)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Conc qualified as Conc
-import Hoard.Effects.Log (Log)
+import Hoard.Effects.Log (Log, withNamespace)
 import Hoard.Effects.Publishing (Sub)
 import Hoard.Effects.Publishing qualified as Sub
 
@@ -22,7 +22,7 @@ run
        , Sub :> es
        )
     => Eff es ()
-run = runListeners
+run = withNamespace "BlockFetch" $ runListeners
 
 
 runListeners

--- a/src/Hoard/BlockFetch/Listeners.hs
+++ b/src/Hoard/BlockFetch/Listeners.hs
@@ -14,7 +14,7 @@ import Ouroboros.Consensus.Block
     , blockSlot
     , getHeader
     )
-import Prelude hiding (State, modify, state)
+import Prelude hiding (State, gets, modify, state)
 
 import Hoard.BlockFetch.Events
     ( BlockBatchCompleted (..)
@@ -43,8 +43,8 @@ blockFetchStarted event = do
 -- Extracts block data and persists it to the database.
 blockReceived :: (Log :> es, State BlocksBeingFetched :> es, BlockRepo :> es) => BlockReceived -> Eff es ()
 blockReceived event = do
-    Log.info "📦 Block received!"
     let block = extractBlockData event
+    Log.info $ "📦 Block received at slot " <> show block.slotNumber <> " (hash: " <> show block.hash <> ")"
     BlockRepo.insertBlocks [block]
     modify $ coerce Set.delete block.hash
     Log.debug $ "Persisted block: " <> show block.hash

--- a/src/Hoard/ChainSync/Listeners.hs
+++ b/src/Hoard/ChainSync/Listeners.hs
@@ -47,7 +47,7 @@ chainSyncStarted
     => ChainSyncStarted
     -> Eff es ()
 chainSyncStarted event = do
-    Log.info $ "⛓️  ChainSync protocol started at " <> show event.timestamp
+    Log.debug $ "⛓️  ChainSync protocol started at " <> show event.timestamp
 
 
 -- | Listener that handles ChainSync rollback events

--- a/src/Hoard/ChainSync/NodeToNode.hs
+++ b/src/Hoard/ChainSync/NodeToNode.hs
@@ -121,7 +121,6 @@ client unlift peer =
     requestNext =
         Yield ChainSync.MsgRequestNext $ Await $ \case
             ChainSync.MsgRollForward header tip -> Effect $ unlift $ do
-                Log.debug "ChainSync: Received header (RollForward)"
                 timestamp <- Clock.currentTime
                 let event =
                         HeaderReceived
@@ -145,7 +144,6 @@ client unlift peer =
                 pure requestNext
             ChainSync.MsgAwaitReply -> Await $ \case
                 ChainSync.MsgRollForward header tip -> Effect $ unlift $ do
-                    Log.debug "ChainSync: Received header after await (RollForward)"
                     timestamp <- Clock.currentTime
                     publish $
                         HeaderReceived

--- a/src/Hoard/Collectors.hs
+++ b/src/Hoard/Collectors.hs
@@ -13,7 +13,6 @@ import Prelude hiding (Reader, State, asks, gets, modify, state)
 
 import Hoard.Bootstrap (bootstrapPeers)
 import Hoard.Collectors.Listeners qualified as Listeners
-import Hoard.Collectors.State (BlocksBeingFetched)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Conc (Conc)
@@ -37,7 +36,6 @@ run
        , PeerRepo :> es
        , Pub :> es
        , Reader Config :> es
-       , State BlocksBeingFetched :> es
        , State HoardState :> es
        , Sub :> es
        )
@@ -56,7 +54,6 @@ runListeners
        , PeerRepo :> es
        , Pub :> es
        , Reader Config :> es
-       , State BlocksBeingFetched :> es
        , State HoardState :> es
        , Sub :> es
        )
@@ -81,7 +78,6 @@ runCollectors
        , Reader Config :> es
        , PeerRepo :> es
        , Pub :> es
-       , State BlocksBeingFetched :> es
        , State HoardState :> es
        , Sub :> es
        )

--- a/src/Hoard/Control/Exception.hs
+++ b/src/Hoard/Control/Exception.hs
@@ -22,7 +22,7 @@ withExceptionLogging protocolName action =
     action `catch` \(e :: SomeException) -> do
         let msg = protocolName <> ": " <> toText (displayException e)
         if isGracefulShutdown e
-            then Log.info $ "graceful shutdown: " <> msg
+            then Log.debug $ "graceful shutdown: " <> msg
             else Log.err $ "error: " <> msg
         throwIO e
 

--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -231,7 +231,7 @@ mkApplication
 mkApplication unlift env codecs peer =
     OuroborosApplication
         [ ChainSync.miniProtocol unlift env.config.cardanoProtocols.chainSync codecs peer
-        , BlockFetch.miniProtocol unlift env.config.cardanoProtocols.blockFetch env.handles.cardanoProtocols.blockFetch codecs peer
+        , BlockFetch.miniProtocol unlift env.config.cardanoProtocols.blockFetch codecs peer
         , KeepAlive.miniProtocol unlift env.config.cardanoProtocols.keepAlive codecs
         , PeerSharing.miniProtocol unlift env.config.cardanoProtocols.peerSharing codecs peer
         , -- TxSubmission mini-protocol (stub - runs forever to avoid terminating)

--- a/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
+++ b/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
@@ -23,9 +23,9 @@ immutableTipRefreshTriggeredListener ImmutableTipRefreshTriggered = refreshImmut
 -- If fetching the tip fails due to a connection error, it retries once to reconnect and fetch.
 refreshImmutableTip :: (Log :> es, NodeToClient :> es, State HoardState :> es) => Eff es ()
 refreshImmutableTip = do
-    Log.debug "Fetching immutable tip from cardano-node..."
+    Log.info "Fetching immutable tip from cardano-node..."
     NodeToClient.immutableTip >>= \case
-        Nothing -> pure ()
+        Nothing -> Log.warn "Failed to fetch immutable tip from cardano-node (connection may be down)"
         Just tip -> do
-            Log.debug ("Immutable tip: " <> show tip)
+            Log.info ("Immutable tip updated: " <> show tip)
             modify (\hoardState -> hoardState {immutableTip = tip})

--- a/test/Unit/Hoard/MonitoringSpec.hs
+++ b/test/Unit/Hoard/MonitoringSpec.hs
@@ -1,37 +1,46 @@
 module Unit.Hoard.MonitoringSpec (spec_Monitoring) where
 
+import Cardano.Api (ChainPoint (..))
 import Data.Default (def)
 import Data.UUID qualified as UUID
-import Effectful (runPureEff)
+import Effectful (runEff)
+import Effectful.Error.Static (runErrorNoCallStack)
+import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState)
 import Effectful.Writer.Static.Shared (execWriter)
 import Test.Hspec (Spec, describe, it, shouldBe)
-import Prelude hiding (evalState)
+import Prelude hiding (evalState, runReader)
 
 import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..))
+import Hoard.Effects.DBRead (runDBRead)
 import Hoard.Effects.Log (Message (..), runLogWriter)
 import Hoard.Monitoring qualified as Monitoring
+import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.Environment (Severity (..))
 import Hoard.Types.HoardState (HoardState (..))
 
 
 spec_Monitoring :: Spec
-spec_Monitoring = do
+spec_Monitoring = withCleanTestDatabase $ do
     describe "listener" do
-        it "reports correct number of peers" do
-            let logs =
-                    fmap (\m -> (m.severity, m.text))
-                        . runPureEff
-                        . execWriter @[Message]
-                        . runLogWriter
-                        . evalState
-                            ( def
-                                { connectedPeers = fromList $ mkPeerIDs 3
-                                }
-                            )
-                        $ Monitoring.listener Monitoring.Poll
-            logs `shouldBe` [(INFO, "Currently connected to 3 peers")]
+        it "reports correct number of peers, immutable tip, and block count" $ \config -> do
+            logs <-
+                runEff
+                    . fmap (fmap (\m -> (m.severity, m.text)))
+                    . execWriter @[Message]
+                    . runLogWriter
+                    . runErrorNoCallStack @Text
+                    . runReader config.pools
+                    . runDBRead
+                    . evalState
+                        ( def
+                            { connectedPeers = fromList $ mkPeerIDs 3
+                            , immutableTip = ChainPointAtGenesis
+                            }
+                        )
+                    $ Monitoring.listener Monitoring.Poll
+            logs `shouldBe` [(INFO, "Currently connected to 3 peers | Immutable tip slot: genesis | Blocks in DB: 0")]
 
 
 mkPeerIDs :: Int -> [ID Peer]


### PR DESCRIPTION
Depends on #209 

Simplifies `BlockFetch` logic by removing the `BlocksBeingFetched` tracking state and the `QSem` logic. Also improves logging with namespaces and more detailed messages, and adds some more info to the monitoring output.

Let's keep things simple for now so we can iterate faster. We can re-add these later when needed.