### PR TITLE
refactor: move Log config to Hoard.Effects.Log

### DIFF
--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -1,7 +1,5 @@
 module Hoard.Types.Environment
     ( ServerConfig (..)
-    , LogConfig (..)
-    , Severity (..)
     , Config (..)
     , Handles (..)
     , Topology (..)
@@ -30,7 +28,6 @@ module Hoard.Types.Environment
     , NodeSocketsConfig (..)
     , SshTunnel (..)
     , Local (..)
-    , defaultLogConfig
     )
 where
 
@@ -42,11 +39,11 @@ import Ouroboros.Network.IOManager (IOManager)
 import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.ChainSync.Config qualified as ChainSync
 import Hoard.Collectors.Config qualified as Collectors
+import Hoard.Effects.Log qualified as Log
 import Hoard.KeepAlive.Config qualified as KeepAlive
 import Hoard.PeerSharing.Config qualified as PeerSharing
 import Hoard.Types.Cardano (CardanoBlock)
 import Hoard.Types.DBConfig (DBPools (..))
-import Hoard.Types.JsonReadShow (JsonReadShow (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 
@@ -59,34 +56,11 @@ data ServerConfig = ServerConfig
     deriving (FromJSON) via QuietSnake ServerConfig
 
 
-data LogConfig = LogConfig
-    { minimumSeverity :: Severity
-    , output :: Handle
-    }
-
-
-data Severity
-    = DEBUG
-    | INFO
-    | WARN
-    | ERROR
-    deriving stock (Eq, Ord, Enum, Bounded, Show, Read)
-    deriving (FromJSON) via (JsonReadShow Severity)
-
-
-defaultLogConfig :: LogConfig
-defaultLogConfig =
-    LogConfig
-        { minimumSeverity = minBound
-        , output = stdout
-        }
-
-
 -- | Pure configuration data loaded from config files
 data Config = Config
     { server :: ServerConfig
     , nodeSockets :: NodeSocketsConfig
-    , logging :: LogConfig
+    , logging :: Log.Config
     , protocolInfo :: ProtocolInfo CardanoBlock
     , nodeConfig :: NodeConfig
     , maxFileDescriptors :: Maybe Word32

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -46,6 +46,7 @@ import Hoard.ChainSync.Config ()
 import Hoard.Collectors.Config ()
 import Hoard.Effects.Environment (loadNodeConfig, loadProtocolInfo)
 import Hoard.Effects.Log (Log, runLog)
+import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Metrics (Metrics, runMetrics)
 import Hoard.Effects.Publishing (Pub, runPubWriter)
 import Hoard.KeepAlive.Config ()
@@ -59,14 +60,12 @@ import Hoard.Types.Environment
     , Env (..)
     , Handles (..)
     , Local (MakeLocal, nodeToClientSocket, tracerSocket)
-    , LogConfig
     , MonitoringConfig (..)
     , NodeSocketsConfig (Local)
     , PeerSnapshotFile (..)
     , ServerConfig (..)
     , Topology (..)
     , TxSubmissionConfig (..)
-    , defaultLogConfig
     )
 import Hoard.Types.HoardState (HoardState)
 
@@ -140,7 +139,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , nodeConfig
                 , protocolInfo
                 , nodeSockets = Local $ MakeLocal {nodeToClientSocket = "preview.socket", tracerSocket = "preview_tracer.socket"}
-                , logging = defaultLogConfig
+                , logging = def
                 , maxFileDescriptors = Nothing
                 , topology = Topology {peerSnapshotFile = "peer-snapshot.json"}
                 , peerSnapshot = PeerSnapshotFile {bigLedgerPools = []}
@@ -178,7 +177,7 @@ type TestAppEffs =
     , Writer [Dynamic]
     , Metrics
     , Log
-    , Reader LogConfig
+    , Reader Log.Config
     , Conc
     , Chan
     , Concurrent

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -1,5 +1,6 @@
 module Integration.DBEffects (spec_DBEffects) where
 
+import Data.Default (def)
 import Data.Time (UTCTime (..))
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
@@ -17,7 +18,6 @@ import Hoard.Effects.DBWrite (runDBWrite, runTransaction)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Metrics (runMetricsNoOp)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
-import Hoard.Types.Environment (defaultLogConfig)
 
 
 spec_DBEffects :: Spec
@@ -70,7 +70,7 @@ spec_DBEffects = withCleanTestDatabase $ do
         it "can write to the database" $ \config -> do
             result <-
                 runEff
-                    . runReader defaultLogConfig
+                    . runReader @Log.Config def
                     . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
@@ -85,7 +85,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- First insert
             _ <-
                 runEff
-                    . runReader defaultLogConfig
+                    . runReader @Log.Config def
                     . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools
@@ -96,7 +96,7 @@ spec_DBEffects = withCleanTestDatabase $ do
             -- Then delete
             result <-
                 runEff
-                    . runReader defaultLogConfig
+                    . runReader @Log.Config def
                     . Log.runLogNoOp
                     . runErrorNoCallStack @Text
                     . runReader config.pools

--- a/test/Unit/Hoard/MonitoringSpec.hs
+++ b/test/Unit/Hoard/MonitoringSpec.hs
@@ -16,11 +16,10 @@ import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.Clock (runClockConst)
 import Hoard.Effects.DBRead (runDBRead)
-import Hoard.Effects.Log (Message (..), runLogWriter)
+import Hoard.Effects.Log (Message (..), Severity (..), runLogWriter)
 import Hoard.Effects.Metrics (runMetricsNoOp)
 import Hoard.Monitoring qualified as Monitoring
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
-import Hoard.Types.Environment (Severity (..))
 import Hoard.Types.HoardState (HoardState (..))
 
 


### PR DESCRIPTION
Helps prevent a cyclic dependency in the Peer Manager PR I'm working on, and it makes sense to let `Log` own its own config.