### PR TITLE
refactor: hide withHistogramTiming's dependency on Clock

### DIFF
--- a/src/Hoard/Effects/DBRead.hs
+++ b/src/Hoard/Effects/DBRead.hs
@@ -15,7 +15,6 @@ import Hasql.Session qualified as Session
 import Hasql.Statement (Statement)
 import Prelude hiding (Reader, asks)
 
-import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Metrics (Metrics, counterInc, withHistogramTiming)
 import Hoard.Effects.Metrics.Definitions (metricDBQueries, metricDBQueryDuration, metricDBQueryErrors)
 import Hoard.Types.DBConfig (DBPools)
@@ -32,7 +31,7 @@ makeEffect ''DBRead
 
 -- | Run the DBRead effect with a connection pool
 runDBRead
-    :: (Error Text :> es, IOE :> es, Reader DBPools :> es, Metrics :> es, Clock :> es)
+    :: (Error Text :> es, IOE :> es, Reader DBPools :> es, Metrics :> es)
     => Eff (DBRead : es) a
     -> Eff es a
 runDBRead eff = do

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -1,7 +1,6 @@
 module Integration.DBEffects (spec_DBEffects) where
 
 import Data.Default (def)
-import Data.Time (UTCTime (..))
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Reader.Static (runReader)
@@ -12,7 +11,6 @@ import Hasql.Transaction qualified as TX
 import Test.Hspec
 import Prelude hiding (runReader)
 
-import Hoard.Effects.Clock (runClockConst)
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite, runTransaction)
 import Hoard.Effects.Log qualified as Log
@@ -22,8 +20,6 @@ import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 
 spec_DBEffects :: Spec
 spec_DBEffects = withCleanTestDatabase $ do
-    let testTime = UTCTime (toEnum 0) 0
-
     describe "DBRead effect" $ do
         it "can read from the database" $ \config -> do
             result <-
@@ -31,7 +27,6 @@ spec_DBEffects = withCleanTestDatabase $ do
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runMetricsNoOp
-                    . runClockConst testTime
                     . runDBRead
                     $ runQuery "count-metadata" countMetadataStmt
 
@@ -58,7 +53,6 @@ spec_DBEffects = withCleanTestDatabase $ do
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runMetricsNoOp
-                    . runClockConst testTime
                     . runDBRead
                     $ runQuery "count-after-insert" countMetadataStmt
 
@@ -112,7 +106,6 @@ spec_DBEffects = withCleanTestDatabase $ do
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runMetricsNoOp
-                    . runClockConst testTime
                     . runDBRead
                     $ runQuery "count-after-delete" countMetadataStmt
 
@@ -128,7 +121,6 @@ spec_DBEffects = withCleanTestDatabase $ do
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runMetricsNoOp
-                    . runClockConst testTime
                     . runDBRead
                     $ runQuery "illegal-insert" insertAsSelectStmt
 

--- a/test/Unit/Hoard/MonitoringSpec.hs
+++ b/test/Unit/Hoard/MonitoringSpec.hs
@@ -2,7 +2,6 @@ module Unit.Hoard.MonitoringSpec (spec_Monitoring) where
 
 import Cardano.Api qualified as C
 import Data.Default (def)
-import Data.Time (UTCTime (..))
 import Data.UUID qualified as UUID
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
@@ -14,7 +13,6 @@ import Prelude hiding (evalState, runReader)
 
 import Hoard.Data.ID (ID (..))
 import Hoard.Data.Peer (Peer (..))
-import Hoard.Effects.Clock (runClockConst)
 import Hoard.Effects.DBRead (runDBRead)
 import Hoard.Effects.Log (Message (..), Severity (..), runLogWriter)
 import Hoard.Effects.Metrics (runMetricsNoOp)
@@ -28,7 +26,6 @@ spec_Monitoring :: Spec
 spec_Monitoring = withCleanTestDatabase $ do
     describe "listener" do
         it "reports correct number of peers, immutable tip, and block count" $ \config -> do
-            let testTime = UTCTime (toEnum 0) 0
             logs <-
                 runEff
                     . fmap (fmap (\m -> (m.severity, m.text)))
@@ -37,7 +34,6 @@ spec_Monitoring = withCleanTestDatabase $ do
                     . runErrorNoCallStack @Text
                     . runReader config.pools
                     . runMetricsNoOp
-                    . runClockConst testTime
                     . runDBRead
                     . evalState
                         ( def


### PR DESCRIPTION
Make `withHistogramTiming` a proper operation on `Metric` to allow us to hide the `Clock` effect it uses in the interpreter. This way we don't have to always include an interpreter for `Clock` in tests where we use `runMetricsNoOp`.

This is what I meant with [this comment](https://github.com/tweag/cardano-hoarding-node/pull/212#discussion_r2736348529).