### PR TITLE
refactor: catch exceptions from Ouroboros

### DIFF
--- a/src/Hoard/Collectors/Listeners.hs
+++ b/src/Hoard/Collectors/Listeners.hs
@@ -173,8 +173,9 @@ collectFromPeer peer = do
     publish $ ConnectingToPeer peer.address
 
     Conc.fork_ $ listen (pickBlockFetchRequest peer.id)
-    _ <- connectToPeer peer
+    connectToPeer peer
 
+    -- This will be reworked with the peer manager
     publish $ ConnectedToPeer peer.address
 
 


### PR DESCRIPTION
In the future, we could drop the whole `isGracefulShutdown` check and instead let the exception propagate upwards if it's supposed to kill the program.