### PR TITLE
feat: add configurable timeout to NodeToNode handshake

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -37,6 +37,11 @@ peer_manager:
   max_collector_lifetime_seconds: 3000 # 50 minutes
   max_concurrent_collectors: 100
 
+node_to_node:
+  # Timeout for TCP connection handshake (in seconds)
+  # This only affects the initial connection, not established connections
+  connection_timeout_seconds: 10
+
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -38,6 +38,11 @@ peer_manager:
   max_collector_lifetime_seconds: 3000 # 50 minutes
   max_concurrent_collectors: 150
 
+node_to_node:
+  # Timeout for TCP connection handshake (in seconds)
+  # This only affects the initial connection, not established connections
+  connection_timeout_seconds: 10
+
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -40,6 +40,11 @@ peer_manager:
   max_collector_lifetime_seconds: 3000 # 50 minutes
   max_concurrent_collectors: 100
 
+node_to_node:
+  # Timeout for TCP connection handshake (in seconds)
+  # This only affects the initial connection, not established connections
+  connection_timeout_seconds: 10
+
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -39,6 +39,11 @@ peer_manager:
   max_collector_lifetime_seconds: 3000 # 50 minutes
   max_concurrent_collectors: 100
 
+node_to_node:
+  # Timeout for TCP connection handshake (in seconds)
+  # This only affects the initial connection, not established connections
+  connection_timeout_seconds: 10
+
 # Cardano protocols configuration
 cardano_protocols:
   peer_sharing:

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -62,6 +62,7 @@ library
       Hoard.Effects.NodeToClient
       Hoard.Effects.NodeToNode
       Hoard.Effects.NodeToNode.Codecs
+      Hoard.Effects.NodeToNode.Config
       Hoard.Effects.Options
       Hoard.Effects.Output
       Hoard.Effects.PeerRepo

--- a/src/Hoard/Effects/Environment.hs
+++ b/src/Hoard/Effects/Environment.hs
@@ -25,6 +25,7 @@ import Prelude hiding (Reader, asks, runReader)
 
 import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
 import Hoard.Effects.Options (Options)
 import Hoard.Effects.Options qualified as Options
 import Hoard.PeerManager.Config qualified as PeerManager
@@ -61,6 +62,7 @@ data ConfigFile = ConfigFile
     , cardanoNodeIntegration :: CardanoNodeIntegrationConfig
     , cardanoProtocolHandles :: CardanoProtocolHandlesConfig
     , peerManager :: PeerManager.Config
+    , nodeToNode :: NodeToNode.Config
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake ConfigFile
@@ -284,6 +286,7 @@ loadEnv eff = withSeqEffToIO \unlift -> withIOManager \ioManager -> unlift do
                 , cardanoProtocols = configFile.cardanoProtocols
                 , monitoring = configFile.monitoring
                 , cardanoNodeIntegration = configFile.cardanoNodeIntegration
+                , nodeToNode = configFile.nodeToNode
                 }
         env = Env {config, handles}
 

--- a/src/Hoard/Effects/NodeToNode/Config.hs
+++ b/src/Hoard/Effects/NodeToNode/Config.hs
@@ -1,0 +1,24 @@
+module Hoard.Effects.NodeToNode.Config (Config (..)) where
+
+import Data.Aeson (FromJSON (..))
+import Data.Default (Default (..))
+import Data.Time (NominalDiffTime)
+
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+
+data Config = Config
+    { connectionTimeoutSeconds :: NominalDiffTime
+    -- ^ Timeout for the TCP connection handshake. If the socket doesn't
+    -- connect within this duration, the connection attempt fails. This does
+    -- NOT affect already-established connections.
+    }
+    deriving stock (Eq, Show, Generic)
+    deriving (FromJSON) via (QuietSnake Config)
+
+
+instance Default Config where
+    def =
+        Config
+            { connectionTimeoutSeconds = 10
+            }

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -39,6 +39,7 @@ import Ouroboros.Network.IOManager (IOManager)
 import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.ChainSync.Config qualified as ChainSync
 import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
 import Hoard.KeepAlive.Config qualified as KeepAlive
 import Hoard.PeerManager.Config qualified as PeerManager
 import Hoard.PeerSharing.Config qualified as PeerSharing
@@ -70,6 +71,7 @@ data Config = Config
     , cardanoProtocols :: CardanoProtocolsConfig
     , monitoring :: MonitoringConfig
     , cardanoNodeIntegration :: CardanoNodeIntegrationConfig
+    , nodeToNode :: NodeToNode.Config
     }
 
 

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -153,6 +153,7 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , monitoring = monitoringCfg
                 , cardanoNodeIntegration = cardanoNodeIntegrationCfg
                 , peerManager = def
+                , nodeToNode = def
                 }
     let handles =
             Handles


### PR DESCRIPTION
Prevents collectors from spending upwards of 60 seconds waiting for a peer that is not online. This will speed up the peer churning and discovery.

Depends #217 