### PR TITLE
refactor: move Monitoring config parsing to Hoard.Monitoring

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -18,6 +18,7 @@ import Hoard.Effects.Chan (runChan)
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.Conc (runConcNewScope)
 import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.ConfigPath (runConfigPath)
 import Hoard.Effects.DBRead (runDBRead)
 import Hoard.Effects.DBWrite (runDBWrite)
 import Hoard.Effects.Environment (loadEnv, runConfigReader, runHandlesReader)
@@ -52,9 +53,11 @@ main =
         . runChan
         . runConcNewScope
         . loadOptions
+        . runConfigPath
         . loadEnv
         . runConfigReader
         . runHandlesReader
+        . Monitoring.runConfig
         . runLog
         . runClock
         . runFileSystem

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -49,6 +49,7 @@ library
       Hoard.Effects.Chan
       Hoard.Effects.Clock
       Hoard.Effects.Conc
+      Hoard.Effects.ConfigPath
       Hoard.Effects.DBRead
       Hoard.Effects.DBWrite
       Hoard.Effects.Environment

--- a/src/Hoard/Effects/ConfigPath.hs
+++ b/src/Hoard/Effects/ConfigPath.hs
@@ -1,0 +1,40 @@
+module Hoard.Effects.ConfigPath
+    ( ConfigPath
+    , runConfigPath
+    , loadYaml
+    ) where
+
+import Data.Aeson (FromJSON (..))
+import Data.String.Conversions (cs)
+import Data.Yaml qualified as Yaml
+import Effectful (Eff, IOE, (:>))
+import Effectful.Exception (throwIO)
+import Effectful.Reader.Static (Reader, asks, runReader)
+import System.FilePath ((</>))
+import System.IO.Error (userError)
+import Prelude hiding (Reader, asks, runReader)
+
+import Hoard.Effects.Options (Options)
+import Hoard.Effects.Options qualified as Options
+import Hoard.Types.Deployment (Deployment (..), deploymentName)
+import Hoard.Types.JsonReadShow (JsonReadShow (..))
+
+
+newtype ConfigPath = ConfigPath FilePath
+    deriving (Eq, Read, Show) via (FilePath)
+    deriving (FromJSON) via (JsonReadShow ConfigPath)
+
+
+runConfigPath :: (Reader Options :> es) => Eff (Reader ConfigPath : es) a -> Eff es a
+runConfigPath eff = do
+    deployment <- asks $ fromMaybe Dev . Options.deployment
+    let configPath = ConfigPath $ "config" </> cs (deploymentName deployment) <> ".yaml"
+    runReader configPath eff
+
+
+loadYaml :: forall a es. (IOE :> es) => (FromJSON a) => ConfigPath -> Eff es a
+loadYaml (ConfigPath path) = do
+    result <- liftIO $ Yaml.decodeFileEither path
+    case result of
+        Left err -> throwIO $ userError $ "Failed to parse " <> path <> ": " <> show err
+        Right configFile -> pure configFile

--- a/src/Hoard/Monitoring.hs
+++ b/src/Hoard/Monitoring.hs
@@ -4,21 +4,26 @@ module Hoard.Monitoring
     , listener
     , runTriggers
     , Poll (..)
+    , runConfig
     ) where
 
 import Cardano.Api qualified as C
+import Data.Aeson (FromJSON (..))
+import Data.Default (Default (..))
 import Data.List (partition)
 import Data.Set qualified as S
-import Effectful (Eff, (:>))
+import Effectful (Eff, IOE, (:>))
 import Effectful.Concurrent (Concurrent)
-import Effectful.Reader.Static (Reader, asks)
+import Effectful.Reader.Static (Reader, ask, asks, runReader)
 import Effectful.State.Static.Shared (State, gets)
-import Prelude hiding (Reader, State, asks, gets)
+import Rel8 (isNull)
+import Prelude hiding (Reader, State, ask, asks, gets, runReader)
 
 import Hoard.DB.Schema (countRows, countRowsWhere)
 import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.ConfigPath (ConfigPath, loadYaml)
 import Hoard.Effects.DBRead (DBRead)
 import Hoard.Effects.Log (Log, withNamespace)
 import Hoard.Effects.Log qualified as Log
@@ -29,9 +34,8 @@ import Hoard.Effects.Publishing qualified as Sub
 import Hoard.PeerManager.Peers (Connection (..), ConnectionState (..), Peers (..))
 import Hoard.Triggers (every)
 import Hoard.Types.Cardano (ChainPoint (ChainPoint))
-import Hoard.Types.Environment (Config (..), MonitoringConfig (..))
 import Hoard.Types.HoardState (HoardState (..))
-import Rel8 (isNull)
+import Hoard.Types.QuietSnake (QuietSnake (..))
 
 
 run
@@ -98,9 +102,38 @@ listener Poll = do
 
 runTriggers :: (Conc :> es, Concurrent :> es, Pub :> es, Reader Config :> es) => Eff es ()
 runTriggers = do
-    pollingInterval <- asks $ (.monitoring.pollingIntervalSeconds)
+    pollingInterval <- asks $ (.pollingIntervalSeconds)
     every pollingInterval $ publish Poll
 
 
 data Poll = Poll
     deriving stock (Show, Typeable)
+
+
+data Config = Config
+    { pollingIntervalSeconds :: Int
+    -- ^ Interval between peer status polling
+    }
+    deriving stock (Generic)
+    deriving (FromJSON) via QuietSnake Config
+
+
+instance Default Config where
+    def =
+        Config
+            { pollingIntervalSeconds = 5
+            }
+
+
+data ConfigFile = ConfigFile
+    { monitoring :: Config
+    }
+    deriving stock (Generic)
+    deriving (FromJSON) via QuietSnake ConfigFile
+
+
+runConfig :: (IOE :> es, Reader ConfigPath :> es) => Eff (Reader Config : es) a -> Eff es a
+runConfig eff = do
+    configPath <- ask
+    configFile <- loadYaml @ConfigFile configPath
+    runReader configFile.monitoring eff

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -11,8 +11,7 @@ module Hoard.Types.Environment
       -- * Cardano protocol handles
     , CardanoProtocolHandles (..)
 
-      -- * Monitoring configuration
-    , MonitoringConfig (..)
+      -- * Tracing configuration
     , TracingConfig (..)
 
       -- * Cardano node integration configuration
@@ -71,7 +70,6 @@ data Config = Config
     , peerSnapshot :: PeerSnapshotFile
     , peerManager :: PeerManager.Config
     , cardanoProtocols :: CardanoProtocolsConfig
-    , monitoring :: MonitoringConfig
     , cardanoNodeIntegration :: CardanoNodeIntegrationConfig
     , nodeToNode :: NodeToNode.Config
     }
@@ -96,15 +94,6 @@ data TxSubmissionConfig = TxSubmissionConfig
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake TxSubmissionConfig
-
-
--- | Monitoring configuration
-data MonitoringConfig = MonitoringConfig
-    { pollingIntervalSeconds :: Int
-    -- ^ Interval between peer status polling
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON) via QuietSnake MonitoringConfig
 
 
 -- | Tracing configuration for OpenTelemetry

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -64,7 +64,6 @@ import Hoard.Types.Environment
     , Env (..)
     , Handles (..)
     , Local (MakeLocal, nodeToClientSocket, tracerSocket)
-    , MonitoringConfig (..)
     , NodeSocketsConfig (Local)
     , PeerSnapshotFile (..)
     , ServerConfig (..)
@@ -128,7 +127,6 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , chainSync = def
                 , txSubmission = TxSubmissionConfig {maximumIngressQueue = 10}
                 }
-    let monitoringCfg = MonitoringConfig {pollingIntervalSeconds = 10}
     let cardanoNodeIntegrationCfg =
             CardanoNodeIntegrationConfig
                 { sshServerAliveIntervalSeconds = 60
@@ -152,7 +150,6 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , topology = Topology {peerSnapshotFile = "peer-snapshot.json"}
                 , peerSnapshot = PeerSnapshotFile {bigLedgerPools = []}
                 , cardanoProtocols
-                , monitoring = monitoringCfg
                 , cardanoNodeIntegration = cardanoNodeIntegrationCfg
                 , peerManager = def
                 , nodeToNode = def


### PR DESCRIPTION
This makes Monitoring entirely self-sufficient, only requiring to know _where_ the config file in question is located through a `Reader ConfigPath` effect.

This is mostly a POC of decentralizing configuration parsing/management and letting each module handle their own config. Up for debate.

Depends #234