### PR TITLE
feat: create Singleflight cache effect

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -46,6 +46,7 @@ library
       Hoard.DB.Schemas.Peers
       Hoard.Effects
       Hoard.Effects.BlockRepo
+      Hoard.Effects.Cache.Singleflight
       Hoard.Effects.Chan
       Hoard.Effects.Clock
       Hoard.Effects.Conc
@@ -308,6 +309,7 @@ test-suite hoard-test
       Unit.Hoard.CollectorSpec
       Unit.Hoard.Data.BlockSpec
       Unit.Hoard.Data.PeerSpec
+      Unit.Hoard.Effects.Cache.SingleflightSpec
       Unit.Hoard.Effects.LogSpec
       Unit.Hoard.Effects.PublishingSpec
       Unit.Hoard.MonitoringSpec

--- a/src/Hoard/Effects/Cache/Singleflight.hs
+++ b/src/Hoard/Effects/Cache/Singleflight.hs
@@ -1,0 +1,137 @@
+module Hoard.Effects.Cache.Singleflight
+    ( Singleflight
+    , withCache
+    , updateCache
+    , runSingleflight
+    ) where
+
+import Data.Map.Strict qualified as Map
+import Effectful (Eff, Effect, (:>))
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM qualified as STM
+import Effectful.Dispatch.Dynamic (interpretWith, localSeqUnlift)
+import Effectful.Exception (throwIO, try)
+import Effectful.TH (makeEffect)
+import Prelude hiding (Reader, ask)
+
+import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, addEvent)
+
+
+-- | Singleflight cache effect for deduplicating concurrent computations
+--
+-- When multiple concurrent operations request the same key:
+-- - The first request executes the computation
+-- - Subsequent requests wait for and share the result
+-- - After completion, all requests receive the same result
+data Singleflight key value :: Effect where
+    -- | Execute a computation with singleflight semantics
+    -- If another computation for the same key is in-flight, wait for its result
+    WithCache :: (Show key, Ord key) => key -> m value -> Singleflight key value m value
+    -- | Pre-populate the cache with known values
+    -- Useful when values are already available to avoid redundant computation
+    UpdateCache :: [(key, value)] -> Singleflight key value m ()
+
+
+makeEffect ''Singleflight
+
+
+type Cache key value = TVar (Map key (TMVar (Either SomeException value)))
+
+
+-- | Run the Singleflight effect with an in-memory cache
+runSingleflight
+    :: forall key value es a
+     . (Ord key, Concurrent :> es, Tracing :> es)
+    => Eff (Singleflight key value : es) a
+    -> Eff es a
+runSingleflight action = do
+    -- Initialize the cache
+    cache :: Cache key value <- STM.newTVarIO Map.empty
+
+    -- Run with the cache in Reader context, interpreting Singleflight operations
+    interpretWith action $ \env -> \case
+        WithCache key computation -> localSeqUnlift env $ \unlift -> do
+            -- Singleflight pattern: check if computation is already in-flight
+            (mvar, isFirst) <- STM.atomically $ do
+                cache' <- STM.readTVar cache
+                case Map.lookup key cache' of
+                    Just tmvar -> pure (tmvar, False) -- Computation already in flight
+                    Nothing -> do
+                        -- Create new empty TMVar and insert into cache
+                        tmvar <- STM.newEmptyTMVar
+                        STM.writeTVar cache (Map.insert key tmvar cache')
+                        pure (tmvar, True) -- We're the first request for this key
+
+            -- Try to read the result (non-blocking check if already filled)
+            mResult <- STM.atomically $ STM.tryReadTMVar mvar
+            case mResult of
+                Just (Right value) -> do
+                    -- Cache hit with successful value
+                    addAttribute "cache.status" "hit"
+                    addEvent "cache_hit" [("cache_key", show key)]
+                    pure value
+                Just (Left exception) -> do
+                    -- Cache hit but it's an exception - re-throw it
+                    addAttribute "cache.status" "hit_exception"
+                    addEvent "cache_hit_exception" [("cache_key", show key)]
+                    throwIO exception
+                Nothing
+                    | isFirst -> do
+                        -- We're the first request - execute computation
+                        addAttribute "cache.status" "miss"
+                        addEvent "cache_miss" [("cache_key", show key)]
+
+                        -- Execute computation and catch any exceptions
+                        result <- unlift $ try @SomeException computation
+
+                        -- Try to fill the TMVar with result (success or failure) for waiters
+                        -- Use tryPutTMVar in case updateCache already filled it
+                        filled <- STM.atomically $ STM.tryPutTMVar mvar result
+
+                        if filled
+                            then do
+                                -- We successfully filled the TMVar with our result
+                                -- If it was an exception, remove from cache so future requests can retry
+                                case result of
+                                    Left _exception -> do
+                                        STM.atomically $ do
+                                            cache' <- STM.readTVar cache
+                                            STM.writeTVar cache (Map.delete key cache')
+                                    Right _ -> pure ()
+
+                                -- Return the result or re-throw the exception
+                                case result of
+                                    Left exception -> throwIO exception
+                                    Right value -> pure value
+                            else do
+                                -- updateCache filled it before us - read and use that value
+                                finalResult <- STM.atomically $ STM.readTMVar mvar
+                                case finalResult of
+                                    Left exception -> throwIO exception
+                                    Right value -> pure value
+                    | otherwise -> do
+                        -- Another request is already executing, wait for it
+                        addAttribute "cache.status" "deduplicated"
+                        addEvent "computation_deduplicated_waiting" [("cache_key", show key)]
+                        result <- STM.atomically $ STM.readTMVar mvar
+                        addEvent "computation_deduplicated_received" [("cache_key", show key)]
+
+                        -- Re-throw if it was an exception, otherwise return the value
+                        case result of
+                            Left exception -> throwIO exception
+                            Right value -> pure value
+        UpdateCache entries -> do
+            STM.atomically $ do
+                cache' <- STM.readTVar cache
+                forM_ entries $ \(key, value) -> do
+                    case Map.lookup key cache' of
+                        Just existingTMVar -> do
+                            -- In-flight computation exists: update its result
+                            -- Try to take whatever value is there (or Nothing if empty)
+                            _ <- STM.tryTakeTMVar existingTMVar
+                            -- Put the correct value (wrapped in Right for success)
+                            STM.putTMVar existingTMVar (Right value)
+                        Nothing -> do
+                            -- No in-flight computation: create fresh TMVar with value
+                            tmvar <- STM.newTMVar (Right value)
+                            STM.modifyTVar cache (Map.insert key tmvar)

--- a/test/Unit/Hoard/Effects/Cache/SingleflightSpec.hs
+++ b/test/Unit/Hoard/Effects/Cache/SingleflightSpec.hs
@@ -1,0 +1,222 @@
+module Unit.Hoard.Effects.Cache.SingleflightSpec (spec_Singleflight) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async qualified as Async
+import Effectful (Eff, IOE, Limit (..), Persistence (..), UnliftStrategy (..), runEff, withEffToIO, (:>))
+import Effectful.Concurrent (Concurrent, runConcurrent)
+import Effectful.Exception (catch, throwIO)
+import Effectful.State.Static.Shared (State, modify, runState)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow)
+import Prelude hiding (State, modify, runState)
+
+import Hoard.Effects.Cache.Singleflight (Singleflight, runSingleflight, updateCache, withCache)
+import Hoard.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
+
+
+-- | Test exception type
+data TestException = TestException Text
+    deriving stock (Show, Eq)
+    deriving anyclass (Exception)
+
+
+-- | Run a Singleflight test with execution counter
+runSingleflightTest
+    :: Eff [Singleflight Int Int, State Int, Tracing, Concurrent, IOE] a
+    -> IO (a, Int)
+runSingleflightTest action =
+    runEff
+        . runConcurrent
+        . runTracingNoOp
+        . runState @Int 0
+        . runSingleflight @Int @Int
+        $ action
+
+
+-- | A computation that increments the execution counter and returns a value
+compute :: (State Int :> es) => Int -> Eff es Int
+compute value = do
+    modify @Int (+ 1)
+    pure value
+
+
+-- | A slow computation that increments the counter
+slowCompute :: (State Int :> es, IOE :> es) => Int -> Eff es Int
+slowCompute value = do
+    liftIO $ threadDelay 10000 -- 10ms
+    modify @Int (+ 1)
+    pure value
+
+
+spec_Singleflight :: Spec
+spec_Singleflight = do
+    describe "Basic Behaviors" $ do
+        describe "First request executes computation" $ do
+            it "executes the computation on first request" $ do
+                (result, execCount) <- runSingleflightTest $ do
+                    withCache 1 (compute 42)
+                result `shouldBe` 42
+                execCount `shouldBe` 1
+
+        describe "Cached value returned on second request" $ do
+            it "returns cached value without re-executing" $ do
+                (result, execCount) <- runSingleflightTest $ do
+                    r1 <- withCache 1 (compute 42)
+                    r2 <- withCache 1 (compute 42)
+                    pure (r1, r2)
+                result `shouldBe` (42, 42)
+                execCount `shouldBe` 1
+
+            it "returns cached value across multiple sequential requests" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    r1 <- withCache 1 (compute 42)
+                    r2 <- withCache 1 (compute 42)
+                    r3 <- withCache 1 (compute 42)
+                    pure [r1, r2, r3]
+                results `shouldBe` [42, 42, 42]
+                execCount `shouldBe` 1
+
+        describe "Concurrent requests are deduplicated" $ do
+            it "executes computation once for concurrent requests" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        -- Launch 10 concurrent requests for the same key
+                        asyncs <- replicateM 10 $ Async.async $ unlift $ withCache 1 (slowCompute 42)
+                        liftIO $ mapM Async.wait asyncs
+                all (== 42) results `shouldBe` True
+                length results `shouldBe` 10
+                execCount `shouldBe` 1
+
+            it "all concurrent waiters receive the same result" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        -- Launch concurrent requests with different delays
+                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute 99)
+                        liftIO $ threadDelay 1000 -- Ensure first request starts
+                        a2 <- Async.async $ unlift $ withCache 1 (compute 99)
+                        a3 <- Async.async $ unlift $ withCache 1 (compute 99)
+                        r1 <- liftIO $ Async.wait a1
+                        r2 <- liftIO $ Async.wait a2
+                        r3 <- liftIO $ Async.wait a3
+                        pure [r1, r2, r3]
+                results `shouldBe` [99, 99, 99]
+                execCount `shouldBe` 1
+
+        describe "Different keys execute independently" $ do
+            it "executes separate computations for different keys" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    r1 <- withCache 1 (compute 10)
+                    r2 <- withCache 2 (compute 20)
+                    r3 <- withCache 3 (compute 30)
+                    pure [r1, r2, r3]
+                results `shouldBe` [10, 20, 30]
+                execCount `shouldBe` 3
+
+            it "different keys can run concurrently" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute 10)
+                        a2 <- Async.async $ unlift $ withCache 2 (slowCompute 20)
+                        a3 <- Async.async $ unlift $ withCache 3 (slowCompute 30)
+                        r1 <- liftIO $ Async.wait a1
+                        r2 <- liftIO $ Async.wait a2
+                        r3 <- liftIO $ Async.wait a3
+                        pure [r1, r2, r3]
+                all (\r -> r `elem` [10, 20, 30]) results `shouldBe` True
+                execCount `shouldBe` 3
+
+        describe "UpdateCache pre-populates the cache" $ do
+            it "returns pre-populated value without executing computation" $ do
+                (result, execCount) <- runSingleflightTest $ do
+                    updateCache [(1, 99)]
+                    withCache 1 (compute 42)
+                result `shouldBe` 99
+                execCount `shouldBe` 0
+
+            it "pre-populated values are returned by subsequent requests" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    updateCache [(1, 99)]
+                    r1 <- withCache 1 (compute 42)
+                    r2 <- withCache 1 (compute 42)
+                    pure [r1, r2]
+                results `shouldBe` [99, 99]
+                execCount `shouldBe` 0
+
+        describe "UpdateCache handles multiple entries" $ do
+            it "correctly handles multiple key-value pairs" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    updateCache [(1, 10), (2, 20), (3, 30)]
+                    r1 <- withCache 1 (compute 99)
+                    r2 <- withCache 2 (compute 99)
+                    r3 <- withCache 3 (compute 99)
+                    pure [r1, r2, r3]
+                results `shouldBe` [10, 20, 30]
+                execCount `shouldBe` 0
+
+        describe "All concurrent waiters receive the result" $ do
+            it "broadcasts result to all waiting requests" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        -- Start one slow computation and many fast waiters
+                        asyncs <- replicateM 20 $ Async.async $ unlift $ withCache 1 (slowCompute 777)
+                        liftIO $ mapM Async.wait asyncs
+                all (== 777) results `shouldBe` True
+                length results `shouldBe` 20
+                execCount `shouldBe` 1
+
+    describe "Edge Cases" $ do
+        describe "Computation throws exception" $ do
+            it "propagates exception to the first caller" $ do
+                let action = runSingleflightTest $ do
+                        withCache @Int @Int 1 (throwIO $ TestException "boom")
+                action `shouldThrow` (\(TestException msg) -> msg == "boom")
+
+            it "exception does not get cached" $ do
+                (result, execCount) <- runSingleflightTest $ do
+                    -- First request throws
+                    _ <-
+                        (withCache @Int @Int 1 (throwIO $ TestException "boom"))
+                            `catch` \(_ :: TestException) -> pure 0
+                    -- Second request should re-execute
+                    withCache 1 (compute 42)
+                result `shouldBe` 42
+                execCount `shouldBe` 1
+
+            it "propagates exception to all concurrent waiters" $ do
+                let action = runSingleflightTest $ do
+                        withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                            a1 <- Async.async $ unlift $ withCache @Int @Int 1 (slowCompute 42 >> throwIO (TestException "concurrent-boom"))
+                            liftIO $ threadDelay 1000
+                            a2 <- Async.async $ unlift $ withCache @Int @Int 1 (compute 99)
+                            _ <- liftIO $ Async.wait a1
+                            liftIO $ Async.wait a2
+                action `shouldThrow` (\(TestException msg) -> msg == "concurrent-boom")
+
+        describe "UpdateCache on in-flight computation" $ do
+            it "overrides result of in-flight computation" $ do
+                (result, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        -- Start slow computation
+                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute 42)
+                        liftIO $ threadDelay 5000 -- Let it start
+                        -- Update cache while computation is running
+                        unlift $ updateCache [(1, 999)]
+                        -- Both should get the updated value
+                        liftIO $ Async.wait a1
+                result `shouldBe` 999
+                execCount `shouldBe` 1
+
+            it "waiting requests receive updated value" $ do
+                (results, execCount) <- runSingleflightTest $ do
+                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
+                        -- Start slow computation and waiters
+                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute 42)
+                        liftIO $ threadDelay 2000
+                        a2 <- Async.async $ unlift $ withCache 1 (compute 42)
+                        liftIO $ threadDelay 2000
+                        -- Update while they're all waiting/running
+                        unlift $ updateCache [(1, 888)]
+                        r1 <- liftIO $ Async.wait a1
+                        r2 <- liftIO $ Async.wait a2
+                        pure [r1, r2]
+                all (== 888) results `shouldBe` True
+                execCount `shouldBe` 1


### PR DESCRIPTION
Depends on #226 

## Summary
Introduces a reusable `Singleflight` cache effect to deduplicate concurrent computations. Applied to `BlockRepo` to prevent redundant database queries when multiple requests check for the same block hash simultaneously.

## Key Features
- **Deduplication**: Single execution for concurrent requests on the same key
- **Exception handling**: Exceptions broadcast to all waiters but aren't cached (enabling retries)
- **Cache pre-population**: `updateCache` allows seeding known values to skip computation
- **Thread-safe**: Built on STM for concurrent access

## Usage Example

```haskell
-- Deduplicate expensive database lookups
runBlockRepo :: (Concurrent :> es, DBRead :> es, DBWrite :> es, Tracing :> es) => Eff (BlockRepo : es) a -> Eff es a
runBlockRepo action = do
    reinterpretWith (Singleflight.runSingleflight @BlockHash @Bool) action $ \_ -> \case
        BlockExists blockHash ->
            Singleflight.withCache blockHash (runQuery "block-exists" $ blockExistsQuery blockHash)
        InsertBlocks blocks -> do
            runTransaction "insert-blocks" $ insertBlocksTrans blocks
            -- Pre-populate cache with known values
            Singleflight.updateCache (map (\b -> (b.hash, True)) blocks)
```

Test output serves as a good overview of the expected behaviour:

```
Singleflight
    Basic Behaviors
      First request executes computation
        executes the computation on first request:                         OK
      Cached value returned on second request
        returns cached value without re-executing:                         OK
        returns cached value across multiple sequential requests:          OK
      Concurrent requests are deduplicated
        executes computation once for concurrent requests:                 OK (0.01s)
        all concurrent waiters receive the same result:                    OK (0.01s)
      Different keys execute independently
        executes separate computations for different keys:                 OK
        different keys can run concurrently:                               OK (0.01s)
      UpdateCache pre-populates the cache
        returns pre-populated value without executing computation:         OK
        pre-populated values are returned by subsequent requests:          OK
      UpdateCache handles multiple entries
        correctly handles multiple key-value pairs:                        OK
      All concurrent waiters receive the result
        broadcasts result to all waiting requests:                         OK (0.01s)
    Edge Cases
      Computation throws exception
        propagates exception to the first caller:                          OK
        exception does not get cached:                                     OK
        propagates exception to all concurrent waiters:                    OK (0.01s)
      UpdateCache on in-flight computation
        overrides result of in-flight computation:                         OK (0.01s)
        waiting requests receive updated value:                            OK (0.01s)
```