### PR TITLE
refactor: parameterize Pub/Sub effects by event type

### DIFF
--- a/src/Hoard/API.hs
+++ b/src/Hoard/API.hs
@@ -32,7 +32,7 @@ type API = NamedRoutes Routes
 
 
 -- | Server implementation, handlers run in Eff monad
-server :: (Pub ::> es, Metrics ::> es, BlockRepo ::> es) => Routes (AsServerT (Eff es))
+server :: (Pub HeaderReceived ::> es, Metrics ::> es, BlockRepo ::> es) => Routes (AsServerT (Eff es))
 server =
     Routes
         { receiveHeader = headerHandler
@@ -42,7 +42,7 @@ server =
 
 
 -- | Handler for header data
-headerHandler :: (Pub ::> es) => Header -> Eff es NoContent
+headerHandler :: (Pub HeaderReceived ::> es) => Header -> Eff es NoContent
 headerHandler headerData = do
     -- Publish event via Publisher effect
     publish $ HeaderReceived headerData

--- a/src/Hoard/BlockFetch.hs
+++ b/src/Hoard/BlockFetch.hs
@@ -2,6 +2,7 @@ module Hoard.BlockFetch (run, runListeners) where
 
 import Effectful (Eff, (:>))
 
+import Hoard.BlockFetch.Events (BlockBatchCompleted, BlockFetchFailed, BlockFetchStarted, BlockReceived)
 import Hoard.BlockFetch.Listeners qualified as Listeners
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Conc (Conc)
@@ -17,7 +18,10 @@ run
        , Conc :> es
        , Tracing :> es
        , Metrics :> es
-       , Sub :> es
+       , Sub BlockFetchStarted :> es
+       , Sub BlockReceived :> es
+       , Sub BlockFetchFailed :> es
+       , Sub BlockBatchCompleted :> es
        )
     => Eff es ()
 run = withSpan "block_fetch" $ do
@@ -29,7 +33,10 @@ runListeners
        , Conc :> es
        , Tracing :> es
        , Metrics :> es
-       , Sub :> es
+       , Sub BlockFetchStarted :> es
+       , Sub BlockReceived :> es
+       , Sub BlockFetchFailed :> es
+       , Sub BlockBatchCompleted :> es
        )
     => Eff es ()
 runListeners = withSpan "listeners" $ do

--- a/src/Hoard/BlockFetch/NodeToNode.hs
+++ b/src/Hoard/BlockFetch/NodeToNode.hs
@@ -50,8 +50,11 @@ miniProtocol
        , Clock :> es
        , Conc :> es
        , Concurrent :> es
-       , Pub :> es
-       , Sub :> es
+       , Pub BlockFetchStarted :> es
+       , Pub BlockFetchFailed :> es
+       , Pub BlockReceived :> es
+       , Pub BlockBatchCompleted :> es
+       , Sub BlockFetchRequest :> es
        , Timeout :> es
        , Tracing :> es
        )
@@ -86,8 +89,11 @@ client
        , Clock :> es
        , Conc :> es
        , Concurrent :> es
-       , Pub :> es
-       , Sub :> es
+       , Pub BlockFetchStarted :> es
+       , Pub BlockFetchFailed :> es
+       , Pub BlockReceived :> es
+       , Pub BlockBatchCompleted :> es
+       , Sub BlockFetchRequest :> es
        , Timeout :> es
        , Tracing :> es
        )

--- a/src/Hoard/ChainSync.hs
+++ b/src/Hoard/ChainSync.hs
@@ -6,6 +6,7 @@ module Hoard.ChainSync
 import Cardano.Api.LedgerState ()
 import Effectful (Eff, (:>))
 
+import Hoard.ChainSync.Events (ChainSyncIntersectionFound, ChainSyncStarted, HeaderReceived, RollBackward, RollForward)
 import Hoard.ChainSync.Listeners qualified as Listeners
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Conc qualified as Conc
@@ -16,12 +17,12 @@ import Hoard.Effects.Publishing (Sub)
 import Hoard.Effects.Publishing qualified as Sub
 
 
-run :: (Tracing :> es, Conc :> es, HeaderRepo :> es, Metrics :> es, Sub :> es) => Eff es ()
+run :: (Tracing :> es, Conc :> es, HeaderRepo :> es, Metrics :> es, Sub HeaderReceived :> es, Sub ChainSyncStarted :> es, Sub RollBackward :> es, Sub RollForward :> es, Sub ChainSyncIntersectionFound :> es) => Eff es ()
 run = withSpan "chain_sync" $ do
     runListeners
 
 
-runListeners :: (Tracing :> es, Conc :> es, HeaderRepo :> es, Metrics :> es, Sub :> es) => Eff es ()
+runListeners :: (Tracing :> es, Conc :> es, HeaderRepo :> es, Metrics :> es, Sub HeaderReceived :> es, Sub ChainSyncStarted :> es, Sub RollBackward :> es, Sub RollForward :> es, Sub ChainSyncIntersectionFound :> es) => Eff es ()
 runListeners = withSpan "listeners" $ do
     _ <- Conc.fork_ $ Sub.listen Listeners.chainSyncHeaderReceived
     _ <- Conc.fork_ $ Sub.listen Listeners.chainSyncStarted

--- a/src/Hoard/ChainSync/NodeToNode.hs
+++ b/src/Hoard/ChainSync/NodeToNode.hs
@@ -42,7 +42,10 @@ miniProtocol
     :: forall es
      . ( State HoardState :> es
        , Clock :> es
-       , Pub :> es
+       , Pub ChainSyncStarted :> es
+       , Pub ChainSyncIntersectionFound :> es
+       , Pub HeaderReceived :> es
+       , Pub RollBackward :> es
        , Tracing :> es
        )
     => (forall x. Eff es x -> IO x)
@@ -77,7 +80,10 @@ miniProtocol unlift conf codecs peer =
 client
     :: forall es
      . ( Clock :> es
-       , Pub :> es
+       , Pub ChainSyncStarted :> es
+       , Pub ChainSyncIntersectionFound :> es
+       , Pub HeaderReceived :> es
+       , Pub RollBackward :> es
        , State HoardState :> es
        , Tracing :> es
        )

--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -29,8 +29,8 @@ collectFromPeer
        , Conc :> es
        , Concurrent :> es
        , NodeToNode :> es
-       , Pub :> es
-       , Sub :> es
+       , Pub BlockFetchRequest :> es
+       , Sub HeaderReceived :> es
        , Tracing :> es
        )
     => Peer
@@ -66,7 +66,7 @@ collectFromPeer peer conn = withSpan "collector.collect_from_peer" $ do
 -- that are not in the database.
 pickBlockFetchRequest
     :: ( BlockRepo :> es
-       , Pub :> es
+       , Pub BlockFetchRequest :> es
        , Tracing :> es
        )
     => ID Peer

--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -59,7 +59,10 @@ import Ouroboros.Network.Snocket (Snocket (..), socketSnocket)
 import System.Timeout qualified as Timeout
 import Prelude hiding (Reader, State, ask, asks, evalState, get, gets)
 
+import Hoard.BlockFetch.Events (BlockBatchCompleted, BlockFetchFailed, BlockFetchRequest, BlockFetchStarted, BlockReceived)
 import Hoard.BlockFetch.NodeToNode qualified as BlockFetch
+import Hoard.ChainSync.Events (ChainSyncIntersectionFound, ChainSyncStarted, RollBackward)
+import Hoard.ChainSync.Events qualified as ChainSync
 import Hoard.ChainSync.NodeToNode qualified as ChainSync
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.Chan (Chan)
@@ -69,7 +72,9 @@ import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, addAttribute,
 import Hoard.Effects.NodeToNode.Codecs (hoistCodecs)
 import Hoard.Effects.NodeToNode.Config (Config (..))
 import Hoard.Effects.Publishing (Pub, Sub)
+import Hoard.KeepAlive.NodeToNode (KeepAlivePing)
 import Hoard.KeepAlive.NodeToNode qualified as KeepAlive
+import Hoard.PeerSharing.Events (PeerSharingStarted, PeersReceived)
 import Hoard.PeerSharing.NodeToNode qualified as PeerSharing
 import Hoard.Types.Cardano (CardanoBlock, CardanoCodecs)
 import Hoard.Types.Environment (CardanoProtocolsConfig (..), Env)
@@ -110,10 +115,20 @@ runNodeToNode
        , Conc :> es
        , Concurrent :> es
        , IOE :> es
-       , Pub :> es
+       , Pub ChainSyncStarted :> es
+       , Pub ChainSyncIntersectionFound :> es
+       , Pub ChainSync.HeaderReceived :> es
+       , Pub RollBackward :> es
+       , Pub BlockFetchStarted :> es
+       , Pub BlockFetchFailed :> es
+       , Pub BlockReceived :> es
+       , Pub BlockBatchCompleted :> es
+       , Sub BlockFetchRequest :> es
+       , Pub KeepAlivePing :> es
+       , Pub PeerSharingStarted :> es
+       , Pub PeersReceived :> es
        , Reader Env :> es
        , State HoardState :> es
-       , Sub :> es
        , Timeout :> es
        , Tracing :> es
        )
@@ -297,9 +312,19 @@ mkApplication
        , Clock :> es
        , Conc :> es
        , Concurrent :> es
-       , Pub :> es
+       , Pub ChainSyncStarted :> es
+       , Pub ChainSyncIntersectionFound :> es
+       , Pub ChainSync.HeaderReceived :> es
+       , Pub RollBackward :> es
+       , Pub BlockFetchStarted :> es
+       , Pub BlockFetchFailed :> es
+       , Pub BlockReceived :> es
+       , Pub BlockBatchCompleted :> es
+       , Sub BlockFetchRequest :> es
+       , Pub KeepAlivePing :> es
+       , Pub PeerSharingStarted :> es
+       , Pub PeersReceived :> es
        , State HoardState :> es
-       , Sub :> es
        , Timeout :> es
        , Tracing :> es
        )

--- a/src/Hoard/Effects/Output.hs
+++ b/src/Hoard/Effects/Output.hs
@@ -11,7 +11,6 @@ where
 
 import Prelude hiding (modify, runState)
 
-import Data.Dynamic qualified as Dyn
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
 import Effectful.State.Static.Local (modify, runState)
@@ -46,8 +45,8 @@ runOutputChan inChan = runOutputEff $ Chan.writeChan inChan
 
 
 -- | Run an Output by publishing values with the `Pub` effect.
-runOutputAsPub :: (Typeable a, Pub :> es) => Eff (Output a : es) x -> Eff es x
-runOutputAsPub = runOutputEff $ publish . Dyn.toDyn
+runOutputAsPub :: (Pub a :> es) => Eff (Output a : es) x -> Eff es x
+runOutputAsPub = runOutputEff publish
 
 
 -- | Collect all values from an Output effect into a list.

--- a/src/Hoard/Effects/Publishing.hs
+++ b/src/Hoard/Effects/Publishing.hs
@@ -8,7 +8,6 @@ module Hoard.Effects.Publishing
     )
 where
 
-import Data.Dynamic qualified as Dyn
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpretWith, interpretWith_, interpret_, localSeqUnlift)
 import Prelude hiding (Reader, State, ask, modify, runState)
@@ -19,41 +18,39 @@ import Hoard.Effects.Chan (Chan)
 import Hoard.Effects.Chan qualified as Chan
 
 
-data Pub :: Effect where
-    Publish :: (Typeable a) => a -> Pub m ()
+data Pub (event :: Type) :: Effect where
+    Publish :: event -> Pub event m ()
 
 
-data Sub :: Effect where
-    Listen :: (Typeable a) => (a -> m ()) -> Sub m Void
+data Sub (event :: Type) :: Effect where
+    Listen :: (event -> m ()) -> Sub event m Void
 
 
 makeEffect ''Pub
 makeEffect ''Sub
 
 
--- | Runs Pub and Sub effects with an internal channel.
-runPubSub :: (Chan :> es) => Eff (Pub : Sub : es) a -> Eff es a
+-- | Runs Pub and Sub effects with an internal channel for a specific event type.
+runPubSub :: forall event es a. (Chan :> es) => Eff (Pub event : Sub event : es) a -> Eff es a
 runPubSub action = do
-    (inChan, _) <- Chan.newChan @Dyn.Dynamic
+    (inChan, _) <- Chan.newChan @event
 
     let handlePub eff = interpretWith_ eff \case
-            Publish event -> Chan.writeChan inChan $ Dyn.toDyn event
+            Publish event -> Chan.writeChan inChan event
 
         handleSub eff = interpretWith eff \env -> \case
             Listen listener -> localSeqUnlift env \unlift -> do
                 chan <- Chan.dupChan inChan
                 forever do
                     event <- Chan.readChan chan
-                    case Dyn.fromDynamic event of
-                        Nothing -> pure ()
-                        Just x -> unlift $ listener x
+                    unlift $ listener event
 
     handleSub . handlePub $ action
 
 
 -- | Handler that uses a provided Writer effect instead of actually publishing.
 -- Useful for testing and inspecting what events were published.
-runPubWriter :: (Writer [Dyn.Dynamic] :> es) => Eff (Pub : es) a -> Eff es a
+runPubWriter :: forall event es a. (Writer [event] :> es) => Eff (Pub event : es) a -> Eff es a
 runPubWriter =
     interpret_ \case
-        Publish event -> tell [Dyn.toDyn event]
+        Publish event -> tell [event]

--- a/src/Hoard/KeepAlive/NodeToNode.hs
+++ b/src/Hoard/KeepAlive/NodeToNode.hs
@@ -36,7 +36,7 @@ miniProtocol
     :: forall es
      . ( Clock :> es
        , Concurrent :> es
-       , Pub :> es
+       , Pub KeepAlivePing :> es
        , Tracing :> es
        )
     => (forall x. Eff es x -> IO x)
@@ -73,7 +73,7 @@ miniProtocol unlift conf codecs peer =
 client
     :: ( Clock :> es
        , Concurrent :> es
-       , Pub :> es
+       , Pub KeepAlivePing :> es
        , Tracing :> es
        )
     => (forall x. Eff es x -> IO x)

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -10,9 +10,12 @@ import Hoard.Effects.HoardStateRepo (HoardStateRepo)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Pub, Sub, listen)
+import Hoard.Events.HeaderReceived (HeaderReceived)
+import Hoard.Events.ImmutableTipRefreshTriggered (ImmutableTipRefreshTriggered)
 import Hoard.Listeners.HeaderReceivedListener (headerReceivedListener)
-import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (immutableTipRefreshTriggeredListener, immutableTipRefreshedListener)
+import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed, immutableTipRefreshTriggeredListener, immutableTipRefreshedListener)
 import Hoard.Listeners.NetworkEventListener (protocolErrorListener)
+import Hoard.Network.Events (ProtocolError)
 import Hoard.Types.HoardState (HoardState)
 
 
@@ -21,8 +24,11 @@ runListeners
        , Tracing :> es
        , NodeToClient :> es
        , State HoardState :> es
-       , Sub :> es
-       , Pub :> es
+       , Sub HeaderReceived :> es
+       , Sub ProtocolError :> es
+       , Sub ImmutableTipRefreshTriggered :> es
+       , Sub ImmutableTipRefreshed :> es
+       , Pub ImmutableTipRefreshed :> es
        , HoardStateRepo :> es
        )
     => Eff es ()

--- a/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
+++ b/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
@@ -23,7 +23,7 @@ import Prelude hiding (State, gets, modify)
 -- This is called regularly and during application setup to initialize the immutable tip
 -- before we start connecting to peers.
 -- If fetching the tip fails due to a connection error, it retries once to reconnect and fetch.
-immutableTipRefreshTriggeredListener :: (NodeToClient :> es, State HoardState :> es, Tracing :> es, Pub :> es) => ImmutableTipRefreshTriggered -> Eff es ()
+immutableTipRefreshTriggeredListener :: (NodeToClient :> es, State HoardState :> es, Tracing :> es, Pub ImmutableTipRefreshed :> es) => ImmutableTipRefreshTriggered -> Eff es ()
 immutableTipRefreshTriggeredListener ImmutableTipRefreshTriggered = withSpan "immutable_tip.refresh" $ do
     addEvent "fetching_immutable_tip" []
     NodeToClient.immutableTip >>= \case

--- a/src/Hoard/Monitoring.hs
+++ b/src/Hoard/Monitoring.hs
@@ -36,12 +36,12 @@ import Rel8 (isNull)
 
 run
     :: ( Concurrent :> es
-       , Pub :> es
+       , Pub Poll :> es
        , Reader Config :> es
        , State HoardState :> es
        , State Peers :> es
        , Conc :> es
-       , Sub :> es
+       , Sub Poll :> es
        , Log :> es
        , DBRead :> es
        , Metrics :> es
@@ -54,7 +54,7 @@ run = do
 
 runListeners
     :: ( Conc :> es
-       , Sub :> es
+       , Sub Poll :> es
        , Log :> es
        , State HoardState :> es
        , State Peers :> es
@@ -96,7 +96,7 @@ listener Poll = do
         Log.info $ "Currently connected to " <> show connectedPeers <> " peers | " <> show pendingPeers <> " peer connections pending | Immutable tip slot: " <> tipSlot <> " | Blocks in DB: " <> show blockCount <> " | Unclassified: " <> show unclassifiedCount <> " | Being classified: " <> show beingClassifiedCount
 
 
-runTriggers :: (Conc :> es, Concurrent :> es, Pub :> es, Reader Config :> es) => Eff es ()
+runTriggers :: (Conc :> es, Concurrent :> es, Pub Poll :> es, Reader Config :> es) => Eff es ()
 runTriggers = do
     pollingInterval <- asks $ (.monitoring.pollingIntervalSeconds)
     every pollingInterval $ publish Poll

--- a/src/Hoard/OrphanDetection.hs
+++ b/src/Hoard/OrphanDetection.hs
@@ -5,6 +5,7 @@ import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.State.Static.Shared (State)
 import Prelude hiding (State)
 
+import Hoard.BlockFetch.Events (BlockReceived)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Clock (Clock)
 import Hoard.Effects.Conc (Conc)
@@ -13,6 +14,7 @@ import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Sub)
 import Hoard.Effects.Publishing qualified as Sub
+import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed)
 import Hoard.OrphanDetection.Listeners qualified as Listeners
 import Hoard.Types.HoardState (HoardState)
 
@@ -25,7 +27,8 @@ run
        , Tracing :> es
        , NodeToClient :> es
        , State HoardState :> es
-       , Sub :> es
+       , Sub BlockReceived :> es
+       , Sub ImmutableTipRefreshed :> es
        )
     => Eff es ()
 run = withSpan "orphan_detection" $ do
@@ -41,7 +44,8 @@ runListeners
        , Tracing :> es
        , NodeToClient :> es
        , State HoardState :> es
-       , Sub :> es
+       , Sub BlockReceived :> es
+       , Sub ImmutableTipRefreshed :> es
        )
     => Eff es ()
 runListeners = withSpan "listeners" $ do

--- a/src/Hoard/PeerSharing.hs
+++ b/src/Hoard/PeerSharing.hs
@@ -7,15 +7,16 @@ import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
 import Hoard.Effects.PeerRepo (PeerRepo)
 import Hoard.Effects.Publishing (Sub)
 import Hoard.Effects.Publishing qualified as Sub
+import Hoard.PeerSharing.Events (PeerSharingFailed, PeerSharingStarted, PeersReceived)
 import Hoard.PeerSharing.Listeners qualified as Listeners
 
 
-run :: (Conc :> es, Sub :> es, PeerRepo :> es, Tracing :> es) => Eff es ()
+run :: (Conc :> es, Sub PeerSharingStarted :> es, Sub PeersReceived :> es, Sub PeerSharingFailed :> es, PeerRepo :> es, Tracing :> es) => Eff es ()
 run = withSpan "peer_sharing" $ do
     runListeners
 
 
-runListeners :: (Conc :> es, Sub :> es, PeerRepo :> es, Tracing :> es) => Eff es ()
+runListeners :: (Conc :> es, Sub PeerSharingStarted :> es, Sub PeersReceived :> es, Sub PeerSharingFailed :> es, PeerRepo :> es, Tracing :> es) => Eff es ()
 runListeners = withSpan "listeners" $ do
     Conc.fork_ $ Sub.listen Listeners.peerSharingStarted
     Conc.fork_ $ Sub.listen Listeners.peersReceived

--- a/src/Hoard/PeerSharing/NodeToNode.hs
+++ b/src/Hoard/PeerSharing/NodeToNode.hs
@@ -35,7 +35,8 @@ miniProtocol
     :: forall es
      . ( Clock :> es
        , Concurrent :> es
-       , Pub :> es
+       , Pub PeerSharingStarted :> es
+       , Pub PeersReceived :> es
        , Tracing :> es
        )
     => (forall x. Eff es x -> IO x)
@@ -79,7 +80,7 @@ miniProtocol unlift' conf codecs peer =
 -- 3. Waits for the configured interval
 -- 4. Loops
 client
-    :: (Concurrent :> es, Clock :> es, Tracing :> es, Pub :> es)
+    :: (Concurrent :> es, Clock :> es, Tracing :> es, Pub PeersReceived :> es)
     => (forall x. Eff es x -> IO x)
     -> Config
     -> Peer

--- a/src/Hoard/Server.hs
+++ b/src/Hoard/Server.hs
@@ -18,6 +18,7 @@ import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (Metrics)
 import Hoard.Effects.Publishing (Pub)
+import Hoard.Events.HeaderReceived (HeaderReceived)
 import Hoard.Types.Environment (Config (..), Env (..), ServerConfig (..))
 
 
@@ -27,7 +28,7 @@ runServer
        , IOE :> es
        , Log :> es
        , Metrics :> es
-       , Pub :> es
+       , Pub HeaderReceived :> es
        , Reader Env :> es
        )
     => Eff es ()

--- a/src/Hoard/Setup.hs
+++ b/src/Hoard/Setup.hs
@@ -47,7 +47,7 @@ setup
        , Reader Config :> es
        , NodeToClient :> es
        , State HoardState :> es
-       , Pub :> es
+       , Pub ImmutableTipRefreshed :> es
        , HoardStateRepo :> es
        )
     => Eff es ()

--- a/src/Hoard/Triggers.hs
+++ b/src/Hoard/Triggers.hs
@@ -13,7 +13,7 @@ import Hoard.Types.Environment (CardanoNodeIntegrationConfig (..), Config (..))
 
 
 -- | Starts all periodic triggers.
-runTriggers :: (Concurrent :> es, Conc :> es, Pub :> es, Reader Config :> es) => Eff es ()
+runTriggers :: (Concurrent :> es, Conc :> es, Pub ImmutableTipRefreshTriggered :> es, Reader Config :> es) => Eff es ()
 runTriggers = do
     refreshInterval <- asks $ (.cardanoNodeIntegration.immutableTipRefreshSeconds)
     every refreshInterval $ publish ImmutableTipRefreshTriggered

--- a/test/Integration/Hoard/IntegrationSpec.hs
+++ b/test/Integration/Hoard/IntegrationSpec.hs
@@ -4,13 +4,13 @@ import Test.Hspec
 
 import Hoard.API (Routes (..))
 import Hoard.Events.HeaderReceived (Header (..), HeaderReceived (..))
-import Hoard.TestHelpers (client, filterEvents, withEffectStackServer)
+import Hoard.TestHelpers (client, withEffectStackServer)
 
 
 spec_HeaderIntegration :: Spec
 spec_HeaderIntegration = describe "Header Integration Tests" $ do
     describe "POST /header" $ do
-        it "receives header data and emits HeaderReceived event" $ do
+        it "receives header data" $ do
             -- Setup: Create test header
             let testHeader = Header {info = "test header info"}
 
@@ -18,7 +18,7 @@ spec_HeaderIntegration = describe "Header Integration Tests" $ do
                 result <- runClient (client.receiveHeader testHeader)
                 liftIO $ result `shouldSatisfy` isRight
 
-            case filterEvents events of
+            case events of
                 [HeaderReceived header] ->
                     header `shouldBe` testHeader
                 xs ->
@@ -40,7 +40,7 @@ spec_HeaderIntegration = describe "Header Integration Tests" $ do
                 liftIO $ result2 `shouldSatisfy` isRight
 
             -- Assert events contain correct data (in order)
-            case filterEvents events of
+            case events of
                 [HeaderReceived h1, HeaderReceived h2] -> do
                     h1 `shouldBe` testHeader1
                     h2 `shouldBe` testHeader2

--- a/test/Unit/Hoard/CollectorSpec.hs
+++ b/test/Unit/Hoard/CollectorSpec.hs
@@ -1,6 +1,5 @@
 module Unit.Hoard.CollectorSpec (spec_Collector) where
 
-import Data.Dynamic (fromDynamic)
 import Data.Time (UTCTime (..))
 import Data.UUID qualified as UUID
 import Effectful (runPureEff)
@@ -105,9 +104,9 @@ spec_Collector = do
                     . runLogNoOp
                     . runTracingNoOp
                     . runWriter
-                    . runPubWriter
+                    . runPubWriter @BlockFetchRequest
                     . runInputConst headerReceived
                     . evalState db
                     . runBlockRepoState
                     $ pickBlockFetchRequest testPeer.id headerReceived
-        in  mapMaybe fromDynamic events
+        in  events

--- a/test/Unit/Hoard/Effects/PublishingSpec.hs
+++ b/test/Unit/Hoard/Effects/PublishingSpec.hs
@@ -3,12 +3,12 @@ module Unit.Hoard.Effects.PublishingSpec (spec_Pub) where
 import Effectful (runPureEff)
 import Test.Hspec (Spec, context, describe, expectationFailure, it, shouldBe)
 
-import Data.Dynamic (fromDynamic)
 import Effectful.Writer.Static.Shared (runWriter)
 import Hoard.Effects.Publishing (publish, runPubWriter)
 
 
 data TestEvent = TestEvent Text
+    deriving (Show, Typeable)
 
 
 spec_Pub :: Spec
@@ -16,19 +16,19 @@ spec_Pub = do
     describe "Writer implementation" $ do
         context "no events published" do
             it "doesn't record events" $ do
-                let ((), events) = runPureEff . runWriter . runPubWriter $ do
+                let ((), events) = runPureEff . runWriter . runPubWriter @TestEvent $ do
                         pure ()
 
                 length events `shouldBe` 0
 
         context "events published" do
             it "records events" $ do
-                let ((), events) = runPureEff . runWriter . runPubWriter $ do
+                let ((), events) = runPureEff . runWriter . runPubWriter @TestEvent $ do
                         publish $ TestEvent "payload"
                         pure ()
 
                 length events `shouldBe` 1
-                case mapMaybe fromDynamic events of
+                case events of
                     [TestEvent payload] ->
                         payload `shouldBe` "payload"
                     xs ->


### PR DESCRIPTION
Closes #223 

Replace `Dynamic`-based runtime type dispatch with compile-time type parameters. `Pub` and `Sub` effects now specify explicit event types in function signatures.

Changes:
- Parameterized `Pub` and `Sub` effect definitions with event type
- Removed `Dynamic` usage and `Typeable` constraints
- Added `runPubSub` handlers in Main.hs for all event types
- Updated test helpers to use typed events instead of `Dynamic`

Benefits:
- Function signatures explicitly show event dependencies
- Eliminates runtime type casting overhead
- One channel per event type instead of all using the same