### PR TITLE
refactor: make Conc a static effect

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -25,7 +25,7 @@ import Hoard.Core (Core (..))
 import Hoard.Effects.BlockRepo (runBlockRepo)
 import Hoard.Effects.Chan (runChan)
 import Hoard.Effects.Clock (runClock)
-import Hoard.Effects.Conc (runConcNewScope)
+import Hoard.Effects.Conc (runConc)
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.ConfigPath (runConfigPath)
 import Hoard.Effects.DBRead (runDBRead)
@@ -63,7 +63,7 @@ main =
         . runConcurrent
         . runTimeout
         . runChan
-        . runConcNewScope
+        . runConc
         . loadOptions
         . runConfigPath
         . loadEnv

--- a/src/Hoard/Effects/Conc.hs
+++ b/src/Hoard/Effects/Conc.hs
@@ -8,88 +8,92 @@ module Hoard.Effects.Conc
     , awaitAll
     , forkTry
 
-      -- * Scope
-    , Scope
-    , scoped
-
       -- * Interpreters
-    , runConcWithKi
-    , runConcNewScope
-
-      -- * Unlift Strategy
-    , concStrat
+    , runConc
     )
 where
 
-import Prelude hiding (atomically)
-
-import Effectful (Eff, Effect, IOE, Limit (..), Persistence (..), UnliftStrategy (..), withEffToIO, (:>))
-import Effectful.Concurrent.STM (atomically, runConcurrent)
-import Effectful.Dispatch.Dynamic (interpret, localUnliftIO)
-import Effectful.TH (makeEffect)
-
+import Effectful
+    ( Dispatch (..)
+    , DispatchOf
+    , Eff
+    , Effect
+    , IOE
+    , Limit (..)
+    , Persistence (..)
+    , (:>)
+    )
+import Effectful.Dispatch.Static
+    ( SideEffects (..)
+    , StaticRep
+    , concUnliftIO
+    , evalStaticRep
+    , unsafeEff
+    , unsafeSeqUnliftIO
+    )
+import Effectful.Dispatch.Static.Primitive (getEnv)
+import Ki (Scope, Thread)
 import Ki qualified
 
 
-data Conc :: Effect where
-    Fork :: m a -> Conc m (Thread a)
-    Fork_ :: m Void -> Conc m ()
-    Await :: Thread a -> Conc m a
-    AwaitAll :: Conc m ()
-    ForkTry :: (Exception e) => m a -> Conc m (Thread (Either e a))
+data Conc :: Effect
+type instance DispatchOf Conc = Static WithSideEffects
+newtype instance StaticRep Conc = Conc Scope
 
 
-newtype Scope = Scope Ki.Scope
+-- | Fork a computation into a distinct thread and immediately return a
+-- reference to said thread.
+fork :: (Conc :> es) => Eff es a -> Eff es (Thread a)
+fork action = unsafeEff \env -> do
+    Conc scope <- getEnv env
+    concUnliftIO env Persistent (Limited 1) \unlift ->
+        Ki.fork scope $ unlift action
 
 
-newtype Thread a = Thread (Ki.Thread a)
+-- | Fork a computation that blocks indefinitely and immediately return. Since
+-- the computation is expected to block indefinitely, there is no use to
+-- `await` the thread, and thus we don't need a thread reference, so this
+-- function does not return one.
+fork_ :: (Conc :> es) => Eff es Void -> Eff es ()
+fork_ action = unsafeEff \env -> do
+    Conc scope <- getEnv env
+    concUnliftIO env Persistent (Limited 1) \unlift ->
+        Ki.fork_ scope $ unlift action
 
 
-makeEffect ''Conc
+-- | Await a forked thread, blocking the current thread until the awaited
+-- thread terminates.
+await :: (Conc :> es) => Thread a -> Eff es a
+await thread = unsafeEff \env -> do
+    -- We don't use the scope here, but we should use `getStaticRep` here to
+    -- ensure we require `Conc` in the context. Otherwise, this function would
+    -- hide the use of `IO` in `unsafeEff_` a bit too well, and its behavior
+    -- might seem unintuitive.
+    Conc _ <- getEnv env
+    atomically $ Ki.await thread
 
 
-scoped :: (IOE :> es) => (Scope -> Eff es a) -> Eff es a
-scoped action = withEffToIO concStrat $ \unlift ->
-    Ki.scoped $ \scope ->
-        unlift
-            . action
-            $ Scope scope
+-- | Await all forked threads in the current scope.
+awaitAll :: (Conc :> es) => Eff es ()
+awaitAll = unsafeEff \env -> do
+    Conc scope <- getEnv env
+    atomically $ Ki.awaitAll scope
 
 
-runConcWithKi :: (IOE :> es) => Scope -> Eff (Conc : es) a -> Eff es a
-runConcWithKi (Scope scope) = interpret $ \env -> \case
-    Fork action ->
-        localUnliftIO env concStrat $ \unlift ->
-            fmap Thread
-                . liftIO
-                . Ki.fork scope
-                $ unlift action
-    Fork_ action ->
-        localUnliftIO env concStrat $ \unlift ->
-            liftIO
-                . Ki.fork_ scope
-                $ unlift action
-    Await (Thread thread) ->
-        runConcurrent
-            . atomically
-            $ Ki.await thread
-    AwaitAll ->
-        runConcurrent
-            . atomically
-            $ Ki.awaitAll scope
-    ForkTry action ->
-        localUnliftIO env concStrat $ \unlift ->
-            fmap Thread
-                . liftIO
-                . Ki.forkTry scope
-                $ unlift action
+-- | Fork a computation and catch all exceptions in an `Either e a`. This will
+-- not catch:
+-- - Synchronous exceptions that do not match `e`
+-- - Asynchronous exceptions
+forkTry :: forall e a es. (Conc :> es, Exception e) => Eff es a -> Eff es (Thread (Either e a))
+forkTry action = unsafeEff \env -> do
+    Conc scope <- getEnv env
+    concUnliftIO env Persistent (Limited 1) \unlift ->
+        Ki.forkTry scope $ unlift action
 
 
-runConcNewScope :: (IOE :> es) => Eff (Conc : es) a -> Eff es a
-runConcNewScope eff = withEffToIO concStrat $ \unlift ->
-    Ki.scoped $ \scope ->
-        unlift $ runConcWithKi (Scope scope) eff
-
-
-concStrat :: UnliftStrategy
-concStrat = ConcUnlift Persistent Unlimited
+-- | Run a `Conc` effect with `Ki`.
+runConc :: (IOE :> es) => Eff (Conc : es) a -> Eff es a
+runConc eff = do
+    unsafeSeqUnliftIO \unlift ->
+        Ki.scoped \scope ->
+            unlift $ evalStaticRep (Conc scope) eff

--- a/src/Hoard/Server.hs
+++ b/src/Hoard/Server.hs
@@ -3,7 +3,7 @@ module Hoard.Server
     )
 where
 
-import Effectful (IOE, withEffToIO, (:>))
+import Effectful (IOE, withSeqEffToIO, (:>))
 import Effectful.Exception (try)
 import Effectful.Reader.Static (Reader, ask)
 import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
@@ -15,7 +15,6 @@ import Hoard.Component (Component (..))
 import Hoard.API (API, server)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Log (Log)
 import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (Metrics)
@@ -49,7 +48,7 @@ instance Component Server es where
 
         -- Run Warp server (blocking call, but runSystem auto-forks start phases)
         let settings = setPort port $ setHost (fromString host) defaultSettings
-        servantApp <- withEffToIO Conc.concStrat \unlift ->
+        servantApp <- withSeqEffToIO \unlift ->
             pure $
                 hoistServer
                     (Proxy @API)

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -19,7 +19,6 @@ import Effectful
     , withEffToIO
     , (:>)
     )
-import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Exception (try)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.Reader.Static (Reader, runReader)
@@ -43,7 +42,7 @@ import Hoard.Data.Block (Block)
 import Hoard.Effects.BlockRepo (BlockRepo, runBlockRepoState)
 import Hoard.Effects.Chan (Chan, runChan)
 import Hoard.Effects.Clock (Clock, runClockConst)
-import Hoard.Effects.Conc (Conc, runConcNewScope)
+import Hoard.Effects.Conc (Conc, runConc)
 import Hoard.Effects.Environment (loadNodeConfig, loadProtocolInfo)
 import Hoard.Effects.Log (Log, runLog)
 import Hoard.Effects.Log qualified as Log
@@ -159,9 +158,8 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
     ((a, finalState), _blockState) <-
         runEff
             . runFileSystem
-            . runConcurrent
             . runChan
-            . runConcNewScope
+            . runConc
             . runReader env.config.logging
             . runLog
             . runClockConst testTime
@@ -183,7 +181,6 @@ type TestAppEffs =
     , Reader Log.Config
     , Conc
     , Chan
-    , Concurrent
     , FileSystem
     , IOE
     ]


### PR DESCRIPTION
According to `Effectful.Dispatch.Static`'s docs:

> Unlike dynamically dispatched effects, statically dispatched effects have a single, set interpretation that cannot be changed at runtime, which makes them useful in specific scenarios. For example:
>
> 1. If you'd like to ensure that a specific effect will behave in a certain way at all times, using a statically dispatched version is the only way to ensure that.
> 2. **If the effect you're about to define has only one reasonable implementation, it makes a lot of sense to make it statically dispatched.**

For `Conc`, there is effectively only 1 sensible implementation with the current set of operations. As such, we can simplify and optimize it by making it a statically interpreted effect.