### PR TITLE
style: use latest fourmolu version from nixos-unstable

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -26,7 +26,6 @@ import Hoard.Effects.BlockRepo (runBlockRepo)
 import Hoard.Effects.Chan (runChan)
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.Conc (runConc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.ConfigPath (runConfigPath)
 import Hoard.Effects.DBRead (runDBRead)
 import Hoard.Effects.DBWrite (runDBWrite)
@@ -46,7 +45,6 @@ import Hoard.Events.ImmutableTipRefreshTriggered (ImmutableTipRefreshTriggered)
 import Hoard.KeepAlive.NodeToNode (KeepAlivePing)
 import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed)
 import Hoard.Monitoring (Monitoring (..), Poll)
-import Hoard.Monitoring qualified as Monitoring
 import Hoard.Network.Events (ProtocolError)
 import Hoard.OrphanDetection (OrphanDetection (..))
 import Hoard.PeerManager (CullRequested, PeerDisconnected, PeerManager (..), PeerRequested)
@@ -55,6 +53,9 @@ import Hoard.PeerSharing (PeerSharing (..))
 import Hoard.PeerSharing.Events (PeerSharingFailed, PeerSharingStarted, PeersReceived)
 import Hoard.Server (Server (..))
 import Hoard.Types.HoardState (HoardState)
+
+import Hoard.Effects.Conc qualified as Conc
+import Hoard.Monitoring qualified as Monitoring
 
 
 main :: IO ()

--- a/flake.lock
+++ b/flake.lock
@@ -742,6 +742,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-nixos-unstable": {
+      "locked": {
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1759070547,
@@ -788,6 +804,7 @@
           "haskell-nix",
           "nixpkgs"
         ],
+        "nixpkgs-nixos-unstable": "nixpkgs-nixos-unstable",
         "sops-nix": "sops-nix",
         "tmp-postgres": "tmp-postgres"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
 
   inputs = {
     nixpkgs.follows = "haskell-nix/nixpkgs";
+    nixpkgs-nixos-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     haskell-nix = {
       url = "github:input-output-hk/haskell.nix";

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,10 +1,16 @@
 { inputs, system }:
+let
+  fourmolu = _: _: {
+    fourmolu = inputs.nixpkgs-nixos-unstable.legacyPackages.${system}.fourmolu;
+  };
+in
 import inputs.haskell-nix.inputs.nixpkgs {
   inherit system;
   overlays = [
     inputs.iohk-nix.overlays.crypto
     inputs.iohk-nix.overlays.haskell-nix-crypto
     inputs.haskell-nix.overlay
+    fourmolu
   ];
   inherit (inputs.haskell-nix) config;
 }

--- a/src/Hoard/API.hs
+++ b/src/Hoard/API.hs
@@ -29,7 +29,7 @@ type API = NamedRoutes Routes
 
 
 -- | Server implementation, handlers run in Eff monad
-server :: (Metrics ::> es, BlockRepo ::> es) => Routes (AsServerT (Eff es))
+server :: (BlockRepo ::> es, Metrics ::> es) => Routes (AsServerT (Eff es))
 server =
     Routes
         { metrics = exportMetrics

--- a/src/Hoard/API/Violations.hs
+++ b/src/Hoard/API/Violations.hs
@@ -9,8 +9,9 @@ import Servant (Get, JSON, QueryParam, type (:-), type (:>))
 import Hoard.Data.BlockViolation (BlockViolation)
 import Hoard.Effects ((::>))
 import Hoard.Effects.BlockRepo (BlockRepo)
-import Hoard.Effects.BlockRepo qualified as BlockRepo
 import Hoard.OrphanDetection.Data (BlockClassification)
+
+import Hoard.Effects.BlockRepo qualified as BlockRepo
 
 
 -- | Violations API type

--- a/src/Hoard/BlockFetch.hs
+++ b/src/Hoard/BlockFetch.hs
@@ -3,13 +3,14 @@ module Hoard.BlockFetch (BlockFetch (..)) where
 import Effectful (Eff, (:>))
 
 import Hoard.BlockFetch.Events (BlockBatchCompleted, BlockFetchFailed, BlockFetchStarted, BlockReceived)
-import Hoard.BlockFetch.Listeners qualified as Listeners
 import Hoard.Component (Component (..), Listener)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Monitoring.Metrics (Metrics)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.Publishing (Sub)
+
+import Hoard.BlockFetch.Listeners qualified as Listeners
 import Hoard.Effects.Publishing qualified as Sub
 
 

--- a/src/Hoard/BlockFetch/Config.hs
+++ b/src/Hoard/BlockFetch/Config.hs
@@ -9,6 +9,7 @@ import Data.Aeson (FromJSON (..))
 import Data.Default (Default (..))
 import Effectful (Eff, (:>))
 import Effectful.Concurrent.QSem (Concurrent, QSem, newQSem)
+
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 

--- a/src/Hoard/BlockFetch/Events.hs
+++ b/src/Hoard/BlockFetch/Events.hs
@@ -33,7 +33,7 @@ data BlockFetchRequest = BlockFetchRequest
     , timestamp :: UTCTime
     , header :: CardanoHeader
     }
-    deriving (Typeable, Eq, Show)
+    deriving (Eq, Show, Typeable)
 
 
 data BlockReceived = BlockReceived

--- a/src/Hoard/Bootstrap.hs
+++ b/src/Hoard/Bootstrap.hs
@@ -2,17 +2,17 @@ module Hoard.Bootstrap (bootstrapPeers) where
 
 import Control.Exception (try)
 import Data.IP (IP)
-import Data.IP qualified as IP
-import Data.Set qualified as S
 import Effectful (Eff, IOE, (:>))
 import Effectful.Reader.Static (Reader, asks)
 import Network.Socket (HostName, PortNumber)
-import Network.Socket qualified as Socket
 import Prelude hiding (Reader, asks)
+
+import Data.IP qualified as IP
+import Data.Set qualified as S
+import Network.Socket qualified as Socket
 
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.Clock (Clock)
-import Hoard.Effects.Clock qualified as Clock
 import Hoard.Effects.PeerRepo (PeerRepo, upsertPeers)
 import Hoard.Types.Environment
     ( BootstrapPeerDomain (..)
@@ -23,11 +23,13 @@ import Hoard.Types.Environment
     )
 import Hoard.Types.NodeIP (NodeIP (..))
 
+import Hoard.Effects.Clock qualified as Clock
+
 
 -- | Bootstrap peers from the peer snapshot configuration.
 -- Extracts all relays from bigLedgerPools, resolves their addresses,
 -- and upserts them to the database.
-bootstrapPeers :: (PeerRepo :> es, Clock :> es, IOE :> es, Reader Config :> es) => Eff es (Set Peer)
+bootstrapPeers :: (Clock :> es, IOE :> es, PeerRepo :> es, Reader Config :> es) => Eff es (Set Peer)
 bootstrapPeers = do
     -- Get peer snapshot from config
     peerSnapshot <- asks (.peerSnapshot)

--- a/src/Hoard/ChainSync.hs
+++ b/src/Hoard/ChainSync.hs
@@ -4,13 +4,14 @@ import Cardano.Api.LedgerState ()
 import Effectful (Eff, (:>))
 
 import Hoard.ChainSync.Events (ChainSyncIntersectionFound, ChainSyncStarted, HeaderReceived, RollBackward, RollForward)
-import Hoard.ChainSync.Listeners qualified as Listeners
 import Hoard.Component (Component (..), Listener)
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.HeaderRepo (HeaderRepo)
 import Hoard.Effects.Monitoring.Metrics (Metrics)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.Publishing (Sub)
+
+import Hoard.ChainSync.Listeners qualified as Listeners
 import Hoard.Effects.Publishing qualified as Sub
 
 

--- a/src/Hoard/ChainSync/Config.hs
+++ b/src/Hoard/ChainSync/Config.hs
@@ -2,6 +2,7 @@ module Hoard.ChainSync.Config (Config (..)) where
 
 import Data.Aeson (FromJSON (..))
 import Data.Default (Default (..))
+
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 

--- a/src/Hoard/ChainSync/Events.hs
+++ b/src/Hoard/ChainSync/Events.hs
@@ -8,8 +8,8 @@ module Hoard.ChainSync.Events
 
 import Cardano.Api.LedgerState ()
 import Data.Time (UTCTime)
-import Hoard.Data.Peer (Peer)
 
+import Hoard.Data.Peer (Peer)
 import Hoard.Types.Cardano (CardanoHeader, CardanoPoint, CardanoTip)
 
 

--- a/src/Hoard/ChainSync/Listeners.hs
+++ b/src/Hoard/ChainSync/Listeners.hs
@@ -30,7 +30,7 @@ import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, addEvent, withSp
 --
 -- Extracts header data and persists it to the database.
 chainSyncHeaderReceived
-    :: (Tracing :> es, HeaderRepo :> es, Metrics :> es)
+    :: (HeaderRepo :> es, Metrics :> es, Tracing :> es)
     => HeaderReceived
     -> Eff es ()
 chainSyncHeaderReceived event = withSpan "header_received" $ do
@@ -57,7 +57,7 @@ chainSyncStarted event = do
 
 -- | Listener that handles ChainSync rollback events
 chainSyncRollBackward
-    :: (Tracing :> es, Metrics :> es)
+    :: (Metrics :> es, Tracing :> es)
     => RollBackward
     -> Eff es ()
 chainSyncRollBackward _event = do
@@ -67,7 +67,7 @@ chainSyncRollBackward _event = do
 
 -- | Listener that handles ChainSync roll forward events
 chainSyncRollForward
-    :: (Tracing :> es, Metrics :> es)
+    :: (Metrics :> es, Tracing :> es)
     => RollForward
     -> Eff es ()
 chainSyncRollForward _event = do

--- a/src/Hoard/Collector.hs
+++ b/src/Hoard/Collector.hs
@@ -15,13 +15,14 @@ import Hoard.Data.BlockHash (blockHashFromHeader)
 import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.BlockRepo (BlockRepo)
-import Hoard.Effects.BlockRepo qualified as BlockRepo
 import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, addEvent, withSpan)
 import Hoard.Effects.NodeToNode (ConnectToError (..), NodeToNode, connectToPeer)
 import Hoard.Effects.Publishing (Pub, Sub, listen, publish)
 import Hoard.PeerManager.Peers (Connection (..), awaitTermination, signalTermination)
+
+import Hoard.Effects.BlockRepo qualified as BlockRepo
+import Hoard.Effects.Conc qualified as Conc
 
 
 collectFromPeer

--- a/src/Hoard/Component.hs
+++ b/src/Hoard/Component.hs
@@ -11,16 +11,18 @@ module Hoard.Component
     , defaultComponentName
     ) where
 
-import Data.Text qualified as Text
 import Data.Typeable (typeRep)
 import Effectful (Eff, (:>))
 import Text.Casing (fromHumps, toSnake)
 
+import Data.Text qualified as Text
+
 import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Log (Log)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
+
+import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.Log qualified as Log
 
 
 -- | Type aliases for semantic clarity
@@ -78,8 +80,8 @@ component = SomeComponent (Proxy @c)
 runComponent
     :: forall c es
      . ( Component c es
-       , Effects c es
        , Conc :> es
+       , Effects c es
        , Tracing :> es
        )
     => Eff es ()
@@ -119,8 +121,8 @@ runSystem components = do
     setupComponent (SomeComponent (p :: Proxy c)) = do
         let name = componentName @c @es p
         Log.debug $ "Setting up component: " <> name
-        withSpan (name <> ":setup") $
-            setup @c @es
+        withSpan (name <> ":setup")
+            $ setup @c @es
 
     startComponent :: SomeComponent es -> Eff es ()
     startComponent (SomeComponent (p :: Proxy c)) = do
@@ -132,9 +134,9 @@ runSystem components = do
     postStartComponent (SomeComponent (p :: Proxy c)) = do
         let name = componentName @c @es p
         Log.debug $ "Forking start phase for component: " <> name
-        void . Conc.fork $
-            withSpan (name <> ":start") $
-                start @c @es
+        void . Conc.fork
+            $ withSpan (name <> ":start")
+            $ start @c @es
 
 
 -- | Auto-derive component name from type name

--- a/src/Hoard/Core.hs
+++ b/src/Hoard/Core.hs
@@ -9,7 +9,6 @@ import Prelude hiding (Reader, State, asks, modify)
 import Hoard.Component (Component (..))
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.HoardStateRepo (HoardStateRepo)
-import Hoard.Effects.HoardStateRepo qualified as HoardStateRepo
 import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Pub, Sub, listen, publish)
@@ -21,6 +20,8 @@ import Hoard.Setup (setFileDescriptorLimit)
 import Hoard.Triggers (every)
 import Hoard.Types.Environment (CardanoNodeIntegrationConfig (..), Config (..))
 import Hoard.Types.HoardState (HoardState (immutableTip))
+
+import Hoard.Effects.HoardStateRepo qualified as HoardStateRepo
 
 
 data Core = Core

--- a/src/Hoard/DB/Schemas/Blocks.hs
+++ b/src/Hoard/DB/Schemas/Blocks.hs
@@ -51,8 +51,8 @@ schema = mkSchema "blocks"
 blockFromRow :: Row Result -> Either Text Block
 blockFromRow row = do
     bd <- decodeCardanoBlock row.blockEra row.blockData
-    pure $
-        Block
+    pure
+        $ Block
             { hash = row.hash
             , slotNumber = row.slotNumber
             , poolId = row.poolId

--- a/src/Hoard/DB/Schemas/HoardState.hs
+++ b/src/Hoard/DB/Schemas/HoardState.hs
@@ -16,6 +16,7 @@ import Rel8
     , TypeInformation (typeName)
     , TypeName (name)
     )
+
 import Rel8 qualified
 
 import Hoard.DB.Schema (mkSchema)

--- a/src/Hoard/DB/Schemas/Peers.hs
+++ b/src/Hoard/DB/Schemas/Peers.hs
@@ -89,7 +89,7 @@ rowFromPeer peer =
 selectPeerByAddress :: PeerAddress -> Query (Row Expr)
 selectPeerByAddress peerAddr = do
     peer <- each schema
-    where_ $
-        peer.address ==. lit peerAddr.host
+    where_
+        $ peer.address ==. lit peerAddr.host
             &&. peer.port ==. lit (fromIntegral peerAddr.port)
     pure peer

--- a/src/Hoard/Data/Block.hs
+++ b/src/Hoard/Data/Block.hs
@@ -6,8 +6,6 @@ module Hoard.Data.Block
 
 import Cardano.Api (EpochSlots (..))
 import Codec.CBOR.Read (DeserialiseFailure)
-import Codec.CBOR.Read qualified as CBOR
-import Codec.CBOR.Write qualified as CBOR
 import Data.Time (UTCTime)
 import Ouroboros.Consensus.Byron.Ledger
     ( ByronBlock
@@ -32,6 +30,9 @@ import Ouroboros.Consensus.Shelley.Ledger
     , decodeShelleyBlock
     , encodeShelleyBlock
     )
+
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
 
 import Hoard.Data.BlockHash (BlockHash)
 import Hoard.Data.Eras (BlockEra (..))

--- a/src/Hoard/Data/BlockHash.hs
+++ b/src/Hoard/Data/BlockHash.hs
@@ -6,19 +6,20 @@ module Hoard.Data.BlockHash
 
 import Cardano.Api.LedgerState ()
 import Data.Aeson (FromJSON, ToJSON)
-import Data.ByteString.Base16 qualified as B16
-import Data.Text.Encoding qualified as Text
 import Ouroboros.Consensus.Block.Abstract (ConvertRawHash, toRawHash)
 import Ouroboros.Network.Block (HeaderHash, blockHash)
 import Rel8 (DBEq, DBOrd, DBType)
+
+import Data.ByteString.Base16 qualified as B16
+import Data.Text.Encoding qualified as Text
 
 import Hoard.Types.Cardano (CardanoBlock, CardanoHeader)
 
 
 -- | Newtype wrapper for block hash
 newtype BlockHash = BlockHash Text
-    deriving stock (Eq, Ord, Generic, Show)
-    deriving newtype (FromJSON, ToJSON, DBEq, DBOrd, DBType)
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (DBEq, DBOrd, DBType, FromJSON, ToJSON)
 
 
 blockHashFromHeader :: CardanoHeader -> BlockHash

--- a/src/Hoard/Data/BlockViolation.hs
+++ b/src/Hoard/Data/BlockViolation.hs
@@ -32,7 +32,7 @@ data BlockViolation = BlockViolation
     , classifiedAt :: Maybe UTCTime
     , receipts :: [ReceiptInfo] -- List of peers that sent us this block
     }
-    deriving (Eq, Show, Generic)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON)
 
 
@@ -41,7 +41,7 @@ data ReceiptInfo = ReceiptInfo
     { peerId :: ID Peer
     , receivedAt :: UTCTime
     }
-    deriving (Eq, Show, Generic)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON, ToJSON)
 
 

--- a/src/Hoard/Data/Eras.hs
+++ b/src/Hoard/Data/Eras.hs
@@ -32,6 +32,6 @@ data BlockEra
     | Babbage
     | Conway
     | Dijkstra
-    deriving (Eq, Show, Enum, Bounded, Read, Generic)
-    deriving (DBType, DBEq) via (ReadShow BlockEra)
+    deriving (Bounded, Enum, Eq, Generic, Read, Show)
     deriving (FromJSON, ToJSON) via (JsonReadShow BlockEra)
+    deriving (DBEq, DBType) via (ReadShow BlockEra)

--- a/src/Hoard/Data/Header.hs
+++ b/src/Hoard/Data/Header.hs
@@ -6,11 +6,11 @@ where
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time (UTCTime)
+import Prelude hiding (id)
 
 import Hoard.Data.BlockHash (BlockHash)
 import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer)
-import Prelude hiding (id)
 
 
 -- | Represents a block header from the Cardano blockchain
@@ -23,8 +23,8 @@ data Header = Header
     , blockNumber :: Word64
     , firstSeenAt :: UTCTime
     }
-    deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON)
+    deriving stock (Eq, Generic, Show)
 
 
 -- | Represents a receipt of a header from a specific peer
@@ -37,5 +37,5 @@ data HeaderReceipt = HeaderReceipt
     , peerId :: ID Peer
     , receivedAt :: UTCTime
     }
-    deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON)
+    deriving stock (Eq, Generic, Show)

--- a/src/Hoard/Data/Peer.hs
+++ b/src/Hoard/Data/Peer.hs
@@ -9,12 +9,13 @@ where
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time (UTCTime)
 import Network.Socket (SockAddr)
-import Text.Show qualified as Show
+import Prelude hiding (id)
 
 import Data.IP qualified as IP
+import Text.Show qualified as Show
+
 import Hoard.Data.ID (ID)
 import Hoard.Types.NodeIP (NodeIP (..))
-import Prelude hiding (id)
 
 
 -- | Represents a peer in the P2P network
@@ -27,8 +28,8 @@ data Peer = Peer
     , lastFailureTime :: Maybe UTCTime
     , discoveredVia :: Text
     }
-    deriving stock (Eq, Generic, Ord, Show)
     deriving (FromJSON, ToJSON)
+    deriving stock (Eq, Generic, Ord, Show)
 
 
 -- | Represents a peer address (host:port)
@@ -36,8 +37,8 @@ data PeerAddress = PeerAddress
     { host :: NodeIP
     , port :: Int
     }
-    deriving stock (Eq, Ord, Generic)
     deriving (FromJSON, ToJSON)
+    deriving stock (Eq, Generic, Ord)
 
 
 instance Show PeerAddress where

--- a/src/Hoard/Data/PoolID.hs
+++ b/src/Hoard/Data/PoolID.hs
@@ -19,8 +19,8 @@ import Hoard.Types.Cardano (CardanoBlock)
 
 
 newtype PoolID = PoolID Text
-    deriving stock (Eq, Ord, Show, Generic)
-    deriving newtype (FromJSON, ToJSON, DBEq, DBOrd, DBType)
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (DBEq, DBOrd, DBType, FromJSON, ToJSON)
 
 
 mkPoolID :: CardanoBlock -> PoolID

--- a/src/Hoard/Effects/Chan.hs
+++ b/src/Hoard/Effects/Chan.hs
@@ -22,12 +22,13 @@ module Hoard.Effects.Chan
     ) where
 
 import Control.Concurrent.Chan.Unagi (InChan, OutChan)
-import Control.Concurrent.Chan.Unagi qualified as Unagi
 import Effectful (Dispatch (..), DispatchOf, Eff, Effect, IOE, (:>))
 import Effectful.Dispatch.Static (SideEffects (..), StaticRep, evalStaticRep, unsafeEff_)
 import Effectful.State.Static.Shared (evalState, get, modify)
 import Effectful.Timeout (Timeout, timeout)
 import Prelude hiding (evalState, get, modify)
+
+import Control.Concurrent.Chan.Unagi qualified as Unagi
 
 
 -- | Effect for creating and operating on bidirectional channels.
@@ -83,8 +84,9 @@ readChanBatched
 readChanBatched timeoutMicroseconds batchSize outChan = do
     evalState @[a] [] $ do
         h <- readChan outChan -- blocking, get first item
-        _ <- timeout timeoutMicroseconds $
-            replicateM_ (batchSize - 1) $ do
+        _ <- timeout timeoutMicroseconds
+            $ replicateM_ (batchSize - 1)
+            $ do
                 x <- readChan outChan
                 modify (x :)
         rest <- get

--- a/src/Hoard/Effects/Conc.hs
+++ b/src/Hoard/Effects/Conc.hs
@@ -33,6 +33,7 @@ import Effectful.Dispatch.Static
     )
 import Effectful.Dispatch.Static.Primitive (getEnv)
 import Ki (Scope, Thread)
+
 import Ki qualified
 
 

--- a/src/Hoard/Effects/ConfigPath.hs
+++ b/src/Hoard/Effects/ConfigPath.hs
@@ -6,7 +6,6 @@ module Hoard.Effects.ConfigPath
 
 import Data.Aeson (FromJSON (..))
 import Data.String.Conversions (cs)
-import Data.Yaml qualified as Yaml
 import Effectful (Eff, IOE, (:>))
 import Effectful.Exception (throwIO)
 import Effectful.Reader.Static (Reader, asks, runReader)
@@ -14,13 +13,16 @@ import System.FilePath ((</>))
 import System.IO.Error (userError)
 import Prelude hiding (Reader, asks, runReader)
 
+import Data.Yaml qualified as Yaml
+
 import Hoard.Effects.Options (Options)
-import Hoard.Effects.Options qualified as Options
 import Hoard.Types.Deployment (Deployment (..), deploymentName)
+
+import Hoard.Effects.Options qualified as Options
 
 
 newtype ConfigPath = ConfigPath FilePath
-    deriving (Eq, Read, Show, FromJSON) via (FilePath)
+    deriving (Eq, FromJSON, Read, Show) via (FilePath)
 
 
 runConfigPath :: (Reader Options :> es) => Eff (Reader ConfigPath : es) a -> Eff es a

--- a/src/Hoard/Effects/DBRead.hs
+++ b/src/Hoard/Effects/DBRead.hs
@@ -10,15 +10,17 @@ import Effectful.Dispatch.Dynamic (interpretWith_)
 import Effectful.Error.Static (Error, throwError)
 import Effectful.Reader.Static (Reader, asks)
 import Effectful.TH
-import Hasql.Pool qualified as Pool
-import Hasql.Session qualified as Session
 import Hasql.Statement (Statement)
 import Prelude hiding (Reader, asks)
+
+import Hasql.Pool qualified as Pool
+import Hasql.Session qualified as Session
 
 import Hoard.Effects.Monitoring.Metrics (Metrics, counterInc, withHistogramTiming)
 import Hoard.Effects.Monitoring.Metrics.Definitions (metricDBQueries, metricDBQueryDuration, metricDBQueryErrors)
 import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, addAttribute, addEvent, setStatus, withSpan)
 import Hoard.Types.DBConfig (DBPools)
+
 import Hoard.Types.DBConfig qualified as DB
 
 
@@ -32,7 +34,7 @@ makeEffect ''DBRead
 
 -- | Run the DBRead effect with a connection pool
 runDBRead
-    :: (Error Text :> es, IOE :> es, Reader DBPools :> es, Metrics :> es, Tracing :> es)
+    :: (Error Text :> es, IOE :> es, Metrics :> es, Reader DBPools :> es, Tracing :> es)
     => Eff (DBRead : es) a
     -> Eff es a
 runDBRead eff = do

--- a/src/Hoard/Effects/DBWrite.hs
+++ b/src/Hoard/Effects/DBWrite.hs
@@ -10,13 +10,15 @@ import Effectful.Dispatch.Dynamic (interpretWith_)
 import Effectful.Error.Static (Error, throwError)
 import Effectful.Reader.Static (Reader, asks)
 import Effectful.TH
-import Hasql.Pool qualified as Pool
-import Hasql.Transaction qualified as Transaction
 import Hasql.Transaction.Sessions (IsolationLevel (ReadCommitted), Mode (Write), transaction)
 import Prelude hiding (Reader, asks)
 
+import Hasql.Pool qualified as Pool
+import Hasql.Transaction qualified as Transaction
+
 import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, addAttribute, addEvent, setStatus, withSpan)
 import Hoard.Types.DBConfig (DBPools)
+
 import Hoard.Types.DBConfig qualified as DB
 
 
@@ -30,7 +32,7 @@ makeEffect ''DBWrite
 
 -- | Run the DBWrite effect with a connection pool
 runDBWrite
-    :: (Error Text :> es, IOE :> es, Tracing :> es, Reader DBPools :> es)
+    :: (Error Text :> es, IOE :> es, Reader DBPools :> es, Tracing :> es)
     => Eff (DBWrite : es) a
     -> Eff es a
 runDBWrite eff = do

--- a/src/Hoard/Effects/Environment.hs
+++ b/src/Hoard/Effects/Environment.hs
@@ -21,11 +21,7 @@ import System.FilePath (takeDirectory, (</>))
 import System.IO.Error (userError)
 import Prelude hiding (Reader, ask, asks, runReader)
 
-import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.Effects.ConfigPath (ConfigPath, loadYaml)
-import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
-import Hoard.PeerManager.Config qualified as PeerManager
 import Hoard.Types.Cardano (CardanoBlock)
 import Hoard.Types.DBConfig (DBConfig (..), DBPools, PoolConfig (..), acquireDatabasePools)
 import Hoard.Types.Environment
@@ -42,6 +38,11 @@ import Hoard.Types.Environment
     , TracingConfig
     )
 import Hoard.Types.QuietSnake (QuietSnake (..))
+
+import Hoard.BlockFetch.Config qualified as BlockFetch
+import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
+import Hoard.PeerManager.Config qualified as PeerManager
 
 
 -- | Top-level config file structure (YAML)
@@ -204,7 +205,7 @@ loadCardanoProtocolHandles configFile = do
 
 
 -- | Acquire runtime handles
-acquireHandles :: (IOE :> es, Concurrent :> es) => IOManager -> ConfigFile -> SecretConfig -> Eff es Handles
+acquireHandles :: (Concurrent :> es, IOE :> es) => IOManager -> ConfigFile -> SecretConfig -> Eff es Handles
 acquireHandles ioManager configFile secrets = do
     databaseHost <- lookupNonEmpty "DB_HOST"
     databasePort <- (>>= readMaybe . toString) <$> lookupNonEmpty "DB_PORT"

--- a/src/Hoard/Effects/HeaderRepo.hs
+++ b/src/Hoard/Effects/HeaderRepo.hs
@@ -9,16 +9,18 @@ import Data.Time (UTCTime)
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.TH (makeEffect)
-
 import Hasql.Transaction (Transaction)
+import Rel8 (lit)
+
 import Hasql.Transaction qualified as TX
-import Hoard.DB.Schemas.HeaderReceipts qualified as HeaderReceiptsSchema
-import Hoard.DB.Schemas.Headers qualified as HeadersSchema
+import Rel8 qualified
+
 import Hoard.Data.Header (Header (..))
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
-import Rel8 (lit)
-import Rel8 qualified
+
+import Hoard.DB.Schemas.HeaderReceipts qualified as HeaderReceiptsSchema
+import Hoard.DB.Schemas.Headers qualified as HeadersSchema
 
 
 -- | Effect for header repository operations
@@ -50,8 +52,8 @@ runHeaderRepo
     -> Eff es a
 runHeaderRepo = interpret_ \case
     UpsertHeader header peer receivedAt ->
-        runTransaction "upsert-header" $
-            upsertHeaderImpl header peer receivedAt
+        runTransaction "upsert-header"
+            $ upsertHeaderImpl header peer receivedAt
 
 
 -- | Upsert a header and record receipt from a peer

--- a/src/Hoard/Effects/Input.hs
+++ b/src/Hoard/Effects/Input.hs
@@ -14,6 +14,7 @@ import Effectful.TH (makeEffect)
 import Prelude hiding (State, atomically, evalState, get, modify, state)
 
 import Hoard.Effects.Chan (Chan, OutChan)
+
 import Hoard.Effects.Chan qualified as Chan
 
 

--- a/src/Hoard/Effects/Log.hs
+++ b/src/Hoard/Effects/Log.hs
@@ -45,7 +45,6 @@ module Hoard.Effects.Log
 
 import Control.Tracer (Tracer (..))
 import Data.Aeson (FromJSON (..))
-import Data.ByteString.Char8 qualified as B8
 import Data.Default (Default (..))
 import Effectful (Eff, Effect, IOE, (:>))
 import Effectful.Dispatch.Dynamic (localSeqUnlift, reinterpret, reinterpretWith)
@@ -54,6 +53,8 @@ import Effectful.TH (makeEffect)
 import Effectful.Writer.Static.Shared (Writer, tell)
 import GHC.Stack (SrcLoc (..))
 import Prelude hiding (Reader, ask, local, runReader)
+
+import Data.ByteString.Char8 qualified as B8
 
 import Hoard.Types.JsonReadShow (JsonReadShow (..))
 
@@ -73,7 +74,7 @@ data Message = Message
 
 
 newtype Namespace = Namespace Text
-    deriving stock (Show, Eq)
+    deriving stock (Eq, Show)
     deriving newtype (IsString)
 
 
@@ -92,7 +93,7 @@ data Severity
     | INFO
     | WARN
     | ERROR
-    deriving stock (Eq, Ord, Enum, Bounded, Show, Read)
+    deriving stock (Bounded, Enum, Eq, Ord, Read, Show)
     deriving (FromJSON) via (JsonReadShow Severity)
 
 
@@ -110,8 +111,8 @@ makeEffect ''Log
 log :: (HasCallStack, Log :> es) => Severity -> Text -> Eff es ()
 log severity text = do
     namespace <- getNamespace
-    withFrozenCallStack $
-        logMsg
+    withFrozenCallStack
+        $ logMsg
             Message
                 { stack = callStack
                 , namespace

--- a/src/Hoard/Effects/Monitoring/Metrics.hs
+++ b/src/Hoard/Effects/Monitoring/Metrics.hs
@@ -41,15 +41,17 @@ module Hoard.Effects.Monitoring.Metrics
     , runMetricsNoOp
     ) where
 
+import Data.Time.Clock (diffUTCTime)
 import Effectful (Eff, Effect, IOE, (:>))
 import Effectful.Dispatch.Dynamic (interpret, interpretWith, localSeqUnlift)
 import Effectful.TH (makeEffect)
-import Prometheus qualified as Prom
-import Prometheus.Metric.GHC qualified as GHC
 import Prelude hiding (Reader, ask)
 
-import Data.Time.Clock (diffUTCTime)
+import Prometheus qualified as Prom
+import Prometheus.Metric.GHC qualified as GHC
+
 import Hoard.Effects.Clock (Clock, currentTime)
+
 import Hoard.Effects.Monitoring.Metrics.Registry qualified as Registry
 
 

--- a/src/Hoard/Effects/Monitoring/Tracing.hs
+++ b/src/Hoard/Effects/Monitoring/Tracing.hs
@@ -45,20 +45,22 @@ module Hoard.Effects.Monitoring.Tracing
     ) where
 
 import Control.Tracer (Tracer (..))
-import Data.HashMap.Strict qualified as HashMap
 import Effectful (Eff, Effect, IOE, (:>))
 import Effectful.Dispatch.Dynamic (interpret, interpretWith, localSeqUnlift)
 import Effectful.Exception (onException)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.TH (makeEffect)
+import Prelude hiding (Reader, ask)
+
+import Data.HashMap.Strict qualified as HashMap
 import OpenTelemetry.Context qualified as Context
 import OpenTelemetry.Context.ThreadLocal qualified as ThreadLocal
 import OpenTelemetry.Trace qualified as OT
 import OpenTelemetry.Trace.Core qualified as OT
-import Prelude hiding (Reader, ask)
+
+import Hoard.Types.Environment (Config (..), TracingConfig (..))
 
 import Hoard.Effects.Monitoring.Tracing.Provider qualified as Provider
-import Hoard.Types.Environment (Config (..), TracingConfig (..))
 
 
 -- | Span status for indicating success or failure

--- a/src/Hoard/Effects/Monitoring/Tracing/Provider.hs
+++ b/src/Hoard/Effects/Monitoring/Tracing/Provider.hs
@@ -7,9 +7,10 @@ module Hoard.Effects.Monitoring.Tracing.Provider
     , shutdownTracingState
     ) where
 
+import System.Environment (setEnv)
+
 import OpenTelemetry.Attributes qualified as OT
 import OpenTelemetry.Trace qualified as OT
-import System.Environment (setEnv)
 
 
 data TracingState = TracingState

--- a/src/Hoard/Effects/NodeToNode/Config.hs
+++ b/src/Hoard/Effects/NodeToNode/Config.hs
@@ -13,7 +13,7 @@ data Config = Config
     -- connect within this duration, the connection attempt fails. This does
     -- NOT affect already-established connections.
     }
-    deriving stock (Eq, Show, Generic)
+    deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via (QuietSnake Config)
 
 

--- a/src/Hoard/Effects/Options.hs
+++ b/src/Hoard/Effects/Options.hs
@@ -1,10 +1,11 @@
 module Hoard.Effects.Options (Options (..), loadOptions) where
 
-import Options.Applicative qualified as Opt
-import Prelude hiding (Reader, runReader)
-
 import Effectful (Eff, IOE, (:>))
 import Effectful.Reader.Static (Reader, runReader)
+import Prelude hiding (Reader, runReader)
+
+import Options.Applicative qualified as Opt
+
 import Hoard.Types.Deployment (Deployment, parseDeployment)
 
 

--- a/src/Hoard/Effects/Output.hs
+++ b/src/Hoard/Effects/Output.hs
@@ -9,15 +9,16 @@ module Hoard.Effects.Output
     )
 where
 
-import Prelude hiding (modify, runState)
-
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
 import Effectful.State.Static.Local (modify, runState)
 import Effectful.TH (makeEffect)
+import Prelude hiding (modify, runState)
+
 import Hoard.Effects.Chan (Chan, InChan)
-import Hoard.Effects.Chan qualified as Chan
 import Hoard.Effects.Publishing (Pub, publish)
+
+import Hoard.Effects.Chan qualified as Chan
 
 
 -- | Output something to whomever cares in a manner that is of no concern for

--- a/src/Hoard/Effects/PeerRepo.hs
+++ b/src/Hoard/Effects/PeerRepo.hs
@@ -14,18 +14,20 @@ import Data.Time (NominalDiffTime, UTCTime, calendarTimeTime)
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpret)
 import Effectful.TH (makeEffect)
+import Hasql.Statement (Statement)
+import Hasql.Transaction (Transaction)
 import Rel8 (in_, lit, select, (&&.), (>.))
+
+import Hasql.Transaction qualified as TX
 import Rel8 qualified
 import Rel8.Expr.Time qualified as Rel8
 
-import Hasql.Statement (Statement)
-import Hasql.Transaction (Transaction)
-import Hasql.Transaction qualified as TX
-import Hoard.DB.Schemas.Peers qualified as PeersSchema
 import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.DBRead (DBRead, runQuery)
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
+
+import Hoard.DB.Schemas.Peers qualified as PeersSchema
 
 
 -- | Effect for peer repository operations
@@ -89,22 +91,22 @@ runPeerRepo
     -> Eff es a
 runPeerRepo = interpret $ \_ -> \case
     UpsertPeers peerAddrs sourcePeer timestamp ->
-        runTransaction "upsert-peers" $
-            upsertPeersImpl peerAddrs sourcePeer timestamp
+        runTransaction "upsert-peers"
+            $ upsertPeersImpl peerAddrs sourcePeer timestamp
     GetPeerByAddress peerAddr ->
-        runQuery "get-peer-by-address" $
-            getPeerByAddressImpl peerAddr
+        runQuery "get-peer-by-address"
+            $ getPeerByAddressImpl peerAddr
     GetAllPeers ->
         runQuery "get-all-peers" getAllPeersImpl
     UpdatePeerFailure peer timestamp ->
-        runTransaction "update-peer-failure" $
-            updatePeerFailureImpl peer timestamp
+        runTransaction "update-peer-failure"
+            $ updatePeerFailureImpl peer timestamp
     UpdateLastConnected peerId timestamp ->
-        runTransaction "update-last-connected" $
-            updateLastConnectedImpl peerId timestamp
+        runTransaction "update-last-connected"
+            $ updateLastConnectedImpl peerId timestamp
     GetEligiblePeers failureTimeout alreadyConnectedPeers limit ->
-        runQuery "get-eligible-peers" $
-            getEligiblePeersImpl failureTimeout alreadyConnectedPeers limit
+        runQuery "get-eligible-peers"
+            $ getEligiblePeersImpl failureTimeout alreadyConnectedPeers limit
 
 
 upsertPeersImpl
@@ -126,8 +128,8 @@ upsertPeersImpl peerAddresses sourcePeer timestamp = do
                 Rel8.Insert
                     { into = PeersSchema.schema
                     , rows =
-                        Rel8.values $
-                            toList peerAddresses <&> \peerAddr ->
+                        Rel8.values
+                            $ toList peerAddresses <&> \peerAddr ->
                                 PeersSchema.Row
                                     { PeersSchema.id = Rel8.unsafeDefault
                                     , PeersSchema.address = lit peerAddr.host
@@ -159,10 +161,10 @@ upsertPeersImpl peerAddresses sourcePeer timestamp = do
 -- | Get a peer from the database by its address and port
 getPeerByAddressImpl :: PeerAddress -> Statement () (Maybe Peer)
 getPeerByAddressImpl peerAddr =
-    fmap extractMaybePeer $
-        Rel8.run $
-            select $
-                PeersSchema.selectPeerByAddress peerAddr
+    fmap extractMaybePeer
+        $ Rel8.run
+        $ select
+        $ PeersSchema.selectPeerByAddress peerAddr
   where
     extractMaybePeer :: [PeersSchema.Row Rel8.Result] -> Maybe Peer
     extractMaybePeer [] = Nothing
@@ -173,10 +175,10 @@ getPeerByAddressImpl peerAddr =
 -- | Get all peers from the database
 getAllPeersImpl :: Statement () (Set Peer)
 getAllPeersImpl =
-    fmap (fromList . map PeersSchema.peerFromRow) $
-        Rel8.run $
-            select $
-                Rel8.each PeersSchema.schema
+    fmap (fromList . map PeersSchema.peerFromRow)
+        $ Rel8.run
+        $ select
+        $ Rel8.each PeersSchema.schema
 
 
 -- | Update a peer's last failure time
@@ -217,17 +219,18 @@ updateLastConnectedImpl peerId timestamp = do
 
 getEligiblePeersImpl :: NominalDiffTime -> Set (ID Peer) -> Word -> Statement () (Set Peer)
 getEligiblePeersImpl failureTimeout currentPeers limit =
-    fmap (fromList . fmap PeersSchema.peerFromRow) $
-        Rel8.run $
-            select $ Rel8.limit limit do
-                peer <- Rel8.each PeersSchema.schema
+    fmap (fromList . fmap PeersSchema.peerFromRow)
+        $ Rel8.run
+        $ select
+        $ Rel8.limit limit do
+            peer <- Rel8.each PeersSchema.schema
 
-                let didNotFailRecently =
-                        Rel8.nullable
-                            Rel8.true
-                            (\ft -> Rel8.diffTime Rel8.now ft >. lit (calendarTimeTime failureTimeout))
-                            peer.lastFailureTime
-                    isNotACurrentPeer = Rel8.not_ $ peer.id `in_` (lit <$> toList currentPeers)
+            let didNotFailRecently =
+                    Rel8.nullable
+                        Rel8.true
+                        (\ft -> Rel8.diffTime Rel8.now ft >. lit (calendarTimeTime failureTimeout))
+                        peer.lastFailureTime
+                isNotACurrentPeer = Rel8.not_ $ peer.id `in_` (lit <$> toList currentPeers)
 
-                Rel8.where_ $ isNotACurrentPeer &&. didNotFailRecently
-                pure peer
+            Rel8.where_ $ isNotACurrentPeer &&. didNotFailRecently
+            pure peer

--- a/src/Hoard/Effects/Publishing.hs
+++ b/src/Hoard/Effects/Publishing.hs
@@ -10,11 +10,12 @@ where
 
 import Effectful (Eff, Effect, (:>))
 import Effectful.Dispatch.Dynamic (interpretWith, interpretWith_, interpret_, localSeqUnlift)
-import Prelude hiding (Reader, State, ask, modify, runState)
-
 import Effectful.TH (makeEffect)
 import Effectful.Writer.Static.Shared (Writer, tell)
+import Prelude hiding (Reader, State, ask, modify, runState)
+
 import Hoard.Effects.Chan (Chan)
+
 import Hoard.Effects.Chan qualified as Chan
 
 

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -5,7 +5,6 @@ import Effectful.State.Static.Shared (State)
 import Prelude hiding (Reader, State)
 
 import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.HoardStateRepo (HoardStateRepo)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.NodeToClient (NodeToClient)
@@ -16,17 +15,19 @@ import Hoard.Listeners.NetworkEventListener (protocolErrorListener)
 import Hoard.Network.Events (ProtocolError)
 import Hoard.Types.HoardState (HoardState)
 
+import Hoard.Effects.Conc qualified as Conc
+
 
 runListeners
     :: ( Conc :> es
-       , Tracing :> es
+       , HoardStateRepo :> es
        , NodeToClient :> es
+       , Pub ImmutableTipRefreshed :> es
        , State HoardState :> es
-       , Sub ProtocolError :> es
        , Sub ImmutableTipRefreshTriggered :> es
        , Sub ImmutableTipRefreshed :> es
-       , Pub ImmutableTipRefreshed :> es
-       , HoardStateRepo :> es
+       , Sub ProtocolError :> es
+       , Tracing :> es
        )
     => Eff es ()
 runListeners = do

--- a/src/Hoard/Monitoring.hs
+++ b/src/Hoard/Monitoring.hs
@@ -5,11 +5,9 @@ module Hoard.Monitoring
     , runConfig
     ) where
 
-import Cardano.Api qualified as C
 import Data.Aeson (FromJSON (..))
 import Data.Default (Default (..))
 import Data.List (partition)
-import Data.Set qualified as S
 import Effectful (Eff, IOE, (:>))
 import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader, ask, asks, runReader)
@@ -17,25 +15,28 @@ import Effectful.State.Static.Shared (State, gets)
 import Rel8 (isNull)
 import Prelude hiding (Reader, State, ask, asks, gets, runReader)
 
+import Cardano.Api qualified as C
+import Data.Set qualified as S
+
 import Hoard.Component (Component (..), Listener, Trigger)
 import Hoard.DB.Schema (countRows, countRowsWhere)
-import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.ConfigPath (ConfigPath, loadYaml)
-
 import Hoard.Effects.DBRead (DBRead)
 import Hoard.Effects.Log (Log, withNamespace)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (Metrics, gaugeSet)
 import Hoard.Effects.Monitoring.Metrics.Definitions (metricBlocksBeingClassified, metricBlocksInDB, metricConnectedPeers, metricUnclassifiedBlocks)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.Publishing (Pub, Sub, publish)
-import Hoard.Effects.Publishing qualified as Sub
 import Hoard.PeerManager.Peers (Connection (..), ConnectionState (..), Peers (..))
 import Hoard.Triggers (every)
 import Hoard.Types.Cardano (ChainPoint (ChainPoint))
 import Hoard.Types.HoardState (HoardState (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
+
+import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
+import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.Publishing qualified as Sub
 
 
 data Monitoring = Monitoring

--- a/src/Hoard/OrphanDetection.hs
+++ b/src/Hoard/OrphanDetection.hs
@@ -13,10 +13,11 @@ import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Sub)
-import Hoard.Effects.Publishing qualified as Sub
 import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed)
-import Hoard.OrphanDetection.Listeners qualified as Listeners
 import Hoard.Types.HoardState (HoardState)
+
+import Hoard.Effects.Publishing qualified as Sub
+import Hoard.OrphanDetection.Listeners qualified as Listeners
 
 
 data OrphanDetection = OrphanDetection
@@ -44,7 +45,7 @@ instance Component OrphanDetection es where
             ]
       where
         withErrorHandling listenerName listener event =
-            withSpan listenerName $
-                runErrorNoCallStack (listener event) >>= \case
+            withSpan listenerName
+                $ runErrorNoCallStack (listener event) >>= \case
                     Left err -> addEvent "listener_error" [("error", err)]
                     Right () -> pure ()

--- a/src/Hoard/OrphanDetection/Data.hs
+++ b/src/Hoard/OrphanDetection/Data.hs
@@ -15,9 +15,9 @@ data BlockClassification
       Canonical
     | -- | Block is permanently orphaned (not on chain, before immutable tip)
       Orphaned
-    deriving (Eq, Show, Read)
-    deriving (DBType, DBEq) via (ReadShow BlockClassification)
+    deriving (Eq, Read, Show)
     deriving (FromJSON, ToJSON) via (JsonReadShow BlockClassification)
+    deriving (DBEq, DBType) via (ReadShow BlockClassification)
 
 
 -- | HTTP API instances for Servant

--- a/src/Hoard/PeerManager/Config.hs
+++ b/src/Hoard/PeerManager/Config.hs
@@ -13,7 +13,7 @@ data Config = Config
     , peerFailureCooldownSeconds :: NominalDiffTime
     , maxConcurrentCollectors :: Word
     }
-    deriving (Eq, Show, Generic)
+    deriving (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake Config
 
 

--- a/src/Hoard/PeerManager/Peers.hs
+++ b/src/Hoard/PeerManager/Peers.hs
@@ -16,6 +16,7 @@ import Prelude hiding (newEmptyMVar, takeMVar, tryPutMVar)
 import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer)
 import Hoard.Effects.Clock (Clock)
+
 import Hoard.Effects.Clock qualified as Clock
 
 

--- a/src/Hoard/PeerSharing.hs
+++ b/src/Hoard/PeerSharing.hs
@@ -1,13 +1,15 @@
 module Hoard.PeerSharing (PeerSharing (..)) where
 
 import Effectful (Eff, (:>))
+
 import Hoard.Component (Component (..), Listener)
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.PeerRepo (PeerRepo)
 import Hoard.Effects.Publishing (Sub)
-import Hoard.Effects.Publishing qualified as Sub
 import Hoard.PeerSharing.Events (PeerSharingFailed, PeerSharingStarted, PeersReceived)
+
+import Hoard.Effects.Publishing qualified as Sub
 import Hoard.PeerSharing.Listeners qualified as Listeners
 
 

--- a/src/Hoard/PeerSharing/Config.hs
+++ b/src/Hoard/PeerSharing/Config.hs
@@ -2,6 +2,7 @@ module Hoard.PeerSharing.Config (Config (..)) where
 
 import Data.Aeson (FromJSON (..))
 import Data.Default (Default (..))
+
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 

--- a/src/Hoard/PeerSharing/Listeners.hs
+++ b/src/Hoard/PeerSharing/Listeners.hs
@@ -24,7 +24,7 @@ peerSharingStarted event = do
 
 -- | Processes PeersReceived events and upserts the peer information into
 -- the database.
-peersReceived :: (Tracing :> es, PeerRepo :> es) => PeersReceived -> Eff es ()
+peersReceived :: (PeerRepo :> es, Tracing :> es) => PeersReceived -> Eff es ()
 peersReceived event = withSpan "peers_received" $ do
     addAttribute "peers.count" (show $ length event.peerAddresses)
     addEvent "peers_received" [("count", show $ length event.peerAddresses)]

--- a/src/Hoard/Server.hs
+++ b/src/Hoard/Server.hs
@@ -10,16 +10,16 @@ import Network.Wai.Handler.Warp (defaultSettings, runSettings, setHost, setPort)
 import Servant (Handler (..), hoistServer, serve)
 import Prelude hiding (Reader, ask)
 
-import Hoard.Component (Component (..))
-
 import Hoard.API (API, server)
+import Hoard.Component (Component (..))
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Log (Log)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (Metrics)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Types.Environment (Config (..), Env (..), ServerConfig (..))
+
+import Hoard.Effects.Log qualified as Log
 
 
 data Server = Server
@@ -49,8 +49,8 @@ instance Component Server es where
         -- Run Warp server (blocking call, but runSystem auto-forks start phases)
         let settings = setPort port $ setHost (fromString host) defaultSettings
         servantApp <- withSeqEffToIO \unlift ->
-            pure $
-                hoistServer
+            pure
+                $ hoistServer
                     (Proxy @API)
                     (Handler . ExceptT . unlift . try)
                     Hoard.API.server

--- a/src/Hoard/Triggers.hs
+++ b/src/Hoard/Triggers.hs
@@ -6,14 +6,15 @@ import Effectful.Reader.Static (Reader, asks)
 import Prelude hiding (Reader, asks)
 
 import Hoard.Effects.Conc (Conc)
-import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.Publishing (Pub, publish)
 import Hoard.Events.ImmutableTipRefreshTriggered (ImmutableTipRefreshTriggered (..))
 import Hoard.Types.Environment (CardanoNodeIntegrationConfig (..), Config (..))
 
+import Hoard.Effects.Conc qualified as Conc
+
 
 -- | Starts all periodic triggers.
-runTriggers :: (Concurrent :> es, Conc :> es, Pub ImmutableTipRefreshTriggered :> es, Reader Config :> es) => Eff es ()
+runTriggers :: (Conc :> es, Concurrent :> es, Pub ImmutableTipRefreshTriggered :> es, Reader Config :> es) => Eff es ()
 runTriggers = do
     refreshInterval <- asks $ (.cardanoNodeIntegration.immutableTipRefreshSeconds)
     Conc.fork_ $ every refreshInterval $ publish ImmutableTipRefreshTriggered

--- a/src/Hoard/Types/Cardano.hs
+++ b/src/Hoard/Types/Cardano.hs
@@ -9,18 +9,19 @@ module Hoard.Types.Cardano
     , ChainPoint (..)
     ) where
 
-import Cardano.Api qualified as C
 import Codec.CBOR.Read (DeserialiseFailure)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.ByteString.Lazy qualified as LBS
 import Network.Mux (Mode (..))
 import Network.Socket (SockAddr)
-import Ouroboros.Consensus.Cardano.Block qualified as Consensus
 import Ouroboros.Consensus.Network.NodeToNode (Codecs (..))
-import Ouroboros.Network.Block qualified as Network
 import Ouroboros.Network.Context (MinimalInitiatorContext, ResponderContext)
 import Ouroboros.Network.Mux (MiniProtocol)
 import Rel8 (DBType, JSONBEncoded (JSONBEncoded))
+
+import Cardano.Api qualified as C
+import Data.ByteString.Lazy qualified as LBS
+import Ouroboros.Consensus.Cardano.Block qualified as Consensus
+import Ouroboros.Network.Block qualified as Network
 
 
 -- We use StandardCrypto which is the standard cryptographic primitives used in
@@ -72,5 +73,5 @@ type CardanoMiniProtocol =
 
 newtype ChainPoint = ChainPoint C.ChainPoint
     deriving (Show)
-    deriving (FromJSON, ToJSON, Eq, Ord) via C.ChainPoint
+    deriving (Eq, FromJSON, Ord, ToJSON) via C.ChainPoint
     deriving (DBType) via JSONBEncoded ChainPoint

--- a/src/Hoard/Types/DBConfig.hs
+++ b/src/Hoard/Types/DBConfig.hs
@@ -8,13 +8,15 @@ module Hoard.Types.DBConfig
 where
 
 import Data.Aeson (FromJSON)
+import Prelude hiding (runReader)
+
 import Hasql.Connection.Setting qualified as Setting
 import Hasql.Connection.Setting.Connection qualified as Connection
 import Hasql.Connection.Setting.Connection.Param qualified as Param
 import Hasql.Pool qualified as Pool
 import Hasql.Pool.Config qualified as Pool
+
 import Hoard.Types.QuietSnake (QuietSnake (..))
-import Prelude hiding (runReader)
 
 
 -- | Connection pool configuration
@@ -52,8 +54,8 @@ acquireDatabasePool :: DBConfig -> IO Pool.Pool
 acquireDatabasePool config = do
     let settings =
             [ Pool.staticConnectionSettings
-                [ Setting.connection $
-                    Connection.params
+                [ Setting.connection
+                    $ Connection.params
                         [ Param.host config.host
                         , Param.port config.port
                         , Param.user config.user

--- a/src/Hoard/Types/Deployment.hs
+++ b/src/Hoard/Types/Deployment.hs
@@ -7,6 +7,7 @@ where
 
 import Data.Aeson (FromJSON (..), withText)
 import Data.String.Conversions (cs)
+
 import Data.Text qualified as T
 
 

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -36,6 +36,10 @@ import Data.Aeson (FromJSON (..), withObject, (.:))
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo)
 import Ouroboros.Network.IOManager (IOManager)
 
+import Hoard.Types.Cardano (CardanoBlock)
+import Hoard.Types.DBConfig (DBPools (..))
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
 import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.ChainSync.Config qualified as ChainSync
 import Hoard.Effects.Log qualified as Log
@@ -43,9 +47,6 @@ import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
 import Hoard.KeepAlive.Config qualified as KeepAlive
 import Hoard.PeerManager.Config qualified as PeerManager
 import Hoard.PeerSharing.Config qualified as PeerSharing
-import Hoard.Types.Cardano (CardanoBlock)
-import Hoard.Types.DBConfig (DBPools (..))
-import Hoard.Types.QuietSnake (QuietSnake (..))
 
 
 -- | HTTP server configuration

--- a/src/Hoard/Types/Header.hs
+++ b/src/Hoard/Types/Header.hs
@@ -3,8 +3,9 @@ module Hoard.Types.Header
     )
 where
 
-import Hoard.Types.Cardano (Crypto)
 import Ouroboros.Consensus.Cardano.Block qualified as Block
+
+import Hoard.Types.Cardano (Crypto)
 
 
 type Header = Block.Header Crypto

--- a/src/Hoard/Types/HoardState.hs
+++ b/src/Hoard/Types/HoardState.hs
@@ -1,7 +1,8 @@
 module Hoard.Types.HoardState (HoardState (..)) where
 
-import Cardano.Api qualified as C
 import Data.Default (Default (..))
+
+import Cardano.Api qualified as C
 import Data.Set qualified as S
 
 import Hoard.Data.BlockHash (BlockHash)

--- a/src/Hoard/Types/JsonReadShow.hs
+++ b/src/Hoard/Types/JsonReadShow.hs
@@ -7,13 +7,13 @@ import Data.Typeable (typeRep)
 newtype JsonReadShow a = JsonReadShow {getJsonReadShow :: a}
 
 
-instance forall a. (Typeable a, Read a) => FromJSON (JsonReadShow a) where
+instance forall a. (Read a, Typeable a) => FromJSON (JsonReadShow a) where
     parseJSON =
         let
             typeName = show $ typeRep $ Proxy @a
         in
-            withText typeName $
-                maybe
+            withText typeName
+                $ maybe
                     (fail $ "Failed to read " <> typeName)
                     (pure . JsonReadShow)
                     . readMaybe

--- a/src/Hoard/Types/NodeIP.hs
+++ b/src/Hoard/Types/NodeIP.hs
@@ -4,12 +4,13 @@ module Hoard.Types.NodeIP
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.IP (IP)
-import Hoard.Types.JsonReadShow (JsonReadShow (..))
 import Rel8 (DBEq, DBType (..), ReadShow (..))
+
+import Hoard.Types.JsonReadShow (JsonReadShow (..))
 
 
 newtype NodeIP = NodeIP {getNodeIP :: IP}
-    deriving stock (Eq, Ord, Generic)
-    deriving (Show, Read) via (IP)
-    deriving (DBType, DBEq) via ReadShow NodeIP
+    deriving stock (Eq, Generic, Ord)
+    deriving (Read, Show) via (IP)
     deriving (FromJSON, ToJSON) via JsonReadShow NodeIP
+    deriving (DBEq, DBType) via ReadShow NodeIP

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -23,8 +23,6 @@ import Effectful.Exception (try)
 import Effectful.FileSystem (FileSystem, runFileSystem)
 import Effectful.Reader.Static (Reader, runReader)
 import Effectful.State.Static.Shared (State, runState)
-import Hasql.Pool qualified as Pool
-import Hasql.Pool.Config qualified as Pool
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.Wai.Handler.Warp (testWithApplication)
 import Ouroboros.Network.IOManager (withIOManager)
@@ -35,8 +33,10 @@ import Servant.Client.Generic (genericClient)
 import Servant.Server (Handler (..))
 import Prelude hiding (Reader, State, atomicModifyIORef', newIORef, readIORef, runReader, runState)
 
+import Hasql.Pool qualified as Pool
+import Hasql.Pool.Config qualified as Pool
+
 import Hoard.API (API, Routes, server)
-import Hoard.BlockFetch.Config qualified as BlockFetch
 import Hoard.ChainSync.Config ()
 import Hoard.Data.Block (Block)
 import Hoard.Effects.BlockRepo (BlockRepo, runBlockRepoState)
@@ -45,7 +45,6 @@ import Hoard.Effects.Clock (Clock, runClockConst)
 import Hoard.Effects.Conc (Conc, runConc)
 import Hoard.Effects.Environment (loadNodeConfig, loadProtocolInfo)
 import Hoard.Effects.Log (Log, runLog)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (Metrics, runMetrics)
 import Hoard.KeepAlive.Config ()
 import Hoard.PeerManager.Config ()
@@ -67,6 +66,9 @@ import Hoard.Types.Environment
     , TxSubmissionConfig (..)
     )
 import Hoard.Types.HoardState (HoardState)
+
+import Hoard.BlockFetch.Config qualified as BlockFetch
+import Hoard.Effects.Log qualified as Log
 
 
 withEffectStackServer

--- a/test/Hoard/TestHelpers/Database.hs
+++ b/test/Hoard/TestHelpers/Database.hs
@@ -184,14 +184,14 @@ runSqitchMigrations config dbName = do
     case exitCode of
         ExitSuccess -> pure ()
         ExitFailure code ->
-            error $
-                cs $
-                    "Failed to run sqitch migrations: "
-                        <> show code
-                        <> "\nstdout: "
-                        <> stdoutput
-                        <> "\nstderr: "
-                        <> stderroutput
+            error
+                $ cs
+                $ "Failed to run sqitch migrations: "
+                    <> show code
+                    <> "\nstdout: "
+                    <> stdoutput
+                    <> "\nstderr: "
+                    <> stderroutput
 
 
 -- | Grant TRUNCATE privileges to hoard_writer for test cleanup
@@ -224,8 +224,8 @@ cleanDatabase config = do
 
     truncateTables :: Text -> Session ()
     truncateTables tableNames =
-        statement () $
-            Statement
+        statement ()
+            $ Statement
                 (cs $ "TRUNCATE TABLE " <> tableNames <> " CASCADE")
                 mempty
                 Decoders.noResult

--- a/test/Integration/DBEffects.hs
+++ b/test/Integration/DBEffects.hs
@@ -4,20 +4,22 @@ import Data.Default (def)
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Reader.Static (runReader)
+import Test.Hspec
+import Prelude hiding (runReader)
+
 import Hasql.Decoders qualified as D
 import Hasql.Encoders qualified as E
 import Hasql.Statement qualified as Statement
 import Hasql.Transaction qualified as TX
-import Test.Hspec
-import Prelude hiding (runReader)
 
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite, runTransaction)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
 import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
+
+import Hoard.Effects.Log qualified as Log
 
 
 spec_DBEffects :: Spec

--- a/test/Integration/Hoard/DB/BlockPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/BlockPersistenceSpec.hs
@@ -17,7 +17,6 @@ import Ouroboros.Consensus.Cardano.Block
         , BlockShelley
         )
     )
-import Rel8 qualified
 import Relude.Unsafe (head, read, (!!))
 import Test.Consensus.Shelley.Examples
     ( examplesAllegra
@@ -31,7 +30,8 @@ import Test.Hspec
 import Test.Util.Serialisation.Examples (Examples (..))
 import Prelude hiding (head, runReader)
 
-import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
+import Rel8 qualified
+
 import Hoard.Data.Block (Block (..))
 import Hoard.Data.BlockHash (blockHashFromHeader)
 import Hoard.Data.PoolID (PoolID (..))
@@ -39,11 +39,13 @@ import Hoard.Effects.BlockRepo (blockExists, insertBlocks, runBlockRepo)
 import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
 import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 import Hoard.Types.Cardano (CardanoBlock)
+
+import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
+import Hoard.Effects.Log qualified as Log
 
 
 spec_BlockPersistence :: Spec

--- a/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
+++ b/test/Integration/Hoard/DB/HeaderPersistenceSpec.hs
@@ -1,18 +1,17 @@
 module Integration.Hoard.DB.HeaderPersistenceSpec (spec_HeaderPersistence) where
 
 import Data.Time (UTCTime, getCurrentTime)
-import Data.UUID.V4 qualified as UUID
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Reader.Static (runReader)
 import Hasql.Statement (Statement)
-import Rel8 qualified
 import Test.Hspec
 import Text.Read (read)
 import Prelude hiding (runReader)
 
-import Hoard.DB.Schemas.HeaderReceipts qualified as HeaderReceiptsSchema
-import Hoard.DB.Schemas.Headers qualified as HeadersSchema
+import Data.UUID.V4 qualified as UUID
+import Rel8 qualified
+
 import Hoard.Data.BlockHash (BlockHash (..))
 import Hoard.Data.Header (Header (..))
 import Hoard.Data.ID (ID (..))
@@ -21,11 +20,14 @@ import Hoard.Effects.Clock (runClock)
 import Hoard.Effects.DBRead (runDBRead, runQuery)
 import Hoard.Effects.DBWrite (runDBWrite)
 import Hoard.Effects.HeaderRepo (runHeaderRepo, upsertHeader)
-import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
 import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
 import Hoard.Effects.PeerRepo (runPeerRepo, upsertPeers)
 import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
+
+import Hoard.DB.Schemas.HeaderReceipts qualified as HeaderReceiptsSchema
+import Hoard.DB.Schemas.Headers qualified as HeadersSchema
+import Hoard.Effects.Log qualified as Log
 
 
 spec_HeaderPersistence :: Spec

--- a/test/Integration/Hoard/IntegrationSpec.hs
+++ b/test/Integration/Hoard/IntegrationSpec.hs
@@ -10,32 +10,37 @@ import Hoard.TestHelpers (client, withEffectStackServer)
 spec_ViolationsIntegration :: Spec
 spec_ViolationsIntegration = describe "Violations API Integration Tests" $ do
     describe "GET /violations" $ do
-        it "returns violations list" $
-            void @IO $
-                withEffectStackServer $ \_ runClient -> do
-                    result <- runClient (client.violations Nothing Nothing Nothing)
-                    liftIO $ result `shouldSatisfy` isRight
+        it "returns violations list"
+            $ void @IO
+            $ withEffectStackServer
+            $ \_ runClient -> do
+                result <- runClient (client.violations Nothing Nothing Nothing)
+                liftIO $ result `shouldSatisfy` isRight
 
-        it "accepts classification query parameter" $
-            void @IO $
-                withEffectStackServer $ \_ runClient -> do
-                    result <- runClient (client.violations (Just Canonical) Nothing Nothing)
-                    liftIO $ result `shouldSatisfy` isRight
+        it "accepts classification query parameter"
+            $ void @IO
+            $ withEffectStackServer
+            $ \_ runClient -> do
+                result <- runClient (client.violations (Just Canonical) Nothing Nothing)
+                liftIO $ result `shouldSatisfy` isRight
 
-        it "accepts minSlot query parameter" $
-            void @IO $
-                withEffectStackServer $ \_ runClient -> do
-                    result <- runClient (client.violations Nothing (Just 1000) Nothing)
-                    liftIO $ result `shouldSatisfy` isRight
+        it "accepts minSlot query parameter"
+            $ void @IO
+            $ withEffectStackServer
+            $ \_ runClient -> do
+                result <- runClient (client.violations Nothing (Just 1000) Nothing)
+                liftIO $ result `shouldSatisfy` isRight
 
-        it "accepts maxSlot query parameter" $
-            void @IO $
-                withEffectStackServer $ \_ runClient -> do
-                    result <- runClient (client.violations Nothing Nothing (Just 2000))
-                    liftIO $ result `shouldSatisfy` isRight
+        it "accepts maxSlot query parameter"
+            $ void @IO
+            $ withEffectStackServer
+            $ \_ runClient -> do
+                result <- runClient (client.violations Nothing Nothing (Just 2000))
+                liftIO $ result `shouldSatisfy` isRight
 
-        it "accepts all query parameters together" $
-            void @IO $
-                withEffectStackServer $ \_ runClient -> do
-                    result <- runClient (client.violations (Just Canonical) (Just 1000) (Just 2000))
-                    liftIO $ result `shouldSatisfy` isRight
+        it "accepts all query parameters together"
+            $ void @IO
+            $ withEffectStackServer
+            $ \_ runClient -> do
+                result <- runClient (client.violations (Just Canonical) (Just 1000) (Just 2000))
+                liftIO $ result `shouldSatisfy` isRight

--- a/test/Integration/Hoard/SchemaSpec.hs
+++ b/test/Integration/Hoard/SchemaSpec.hs
@@ -4,20 +4,22 @@ import Data.Time (UTCTime (..))
 import Effectful (runEff)
 import Effectful.Error.Static (runErrorNoCallStack)
 import Effectful.Reader.Static (runReader)
-import Rel8 qualified
 import Test.Hspec
 import Prelude hiding (runReader)
+
+import Rel8 qualified
+
+import Hoard.Effects.Clock (runClockConst)
+import Hoard.Effects.DBRead (runDBRead, runQuery)
+import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
+import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
+import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 
 import Hoard.DB.Schemas.Blocks qualified as BlocksSchema
 import Hoard.DB.Schemas.Headers qualified as HeaderReceiptsSchema
 import Hoard.DB.Schemas.Headers qualified as HeadersSchema
 import Hoard.DB.Schemas.HoardState qualified as HoadStateSchema
 import Hoard.DB.Schemas.Peers qualified as PeersSchema
-import Hoard.Effects.Clock (runClockConst)
-import Hoard.Effects.DBRead (runDBRead, runQuery)
-import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
-import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
-import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
 
 
 spec_Schema :: Spec

--- a/test/Unit/Hoard/CollectorSpec.hs
+++ b/test/Unit/Hoard/CollectorSpec.hs
@@ -1,7 +1,6 @@
 module Unit.Hoard.CollectorSpec (spec_Collector) where
 
 import Data.Time (UTCTime (..))
-import Data.UUID qualified as UUID
 import Effectful (runPureEff)
 import Effectful.State.Static.Shared (evalState)
 import Effectful.Writer.Static.Shared (runWriter)
@@ -13,6 +12,8 @@ import Test.Consensus.Shelley.Examples (examplesShelley)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Util.Serialisation.Examples (Examples (..))
 import Prelude hiding (evalState, execState)
+
+import Data.UUID qualified as UUID
 
 import Hoard.BlockFetch.Events (BlockFetchRequest (..))
 import Hoard.ChainSync.Events (HeaderReceived (..))

--- a/test/Unit/Hoard/Data/BlockSpec.hs
+++ b/test/Unit/Hoard/Data/BlockSpec.hs
@@ -1,8 +1,6 @@
 module Unit.Hoard.Data.BlockSpec (spec_Block) where
 
 import Ouroboros.Consensus.Cardano.Block (HardForkBlock (..))
-import Relude.Unsafe qualified
-import Test.Consensus.Byron.Examples qualified as Byron
 import Test.Consensus.Shelley.Examples
     ( examplesAllegra
     , examplesAlonzo
@@ -14,6 +12,9 @@ import Test.Consensus.Shelley.Examples
     )
 import Test.Hspec
 import Test.Util.Serialisation.Examples (Examples (..))
+
+import Relude.Unsafe qualified
+import Test.Consensus.Byron.Examples qualified as Byron
 
 import Hoard.Data.Block (decodeCardanoBlock, encodeCardanoBlock)
 import Hoard.Data.Eras (BlockEra (..))

--- a/test/Unit/Hoard/Data/PeerSpec.hs
+++ b/test/Unit/Hoard/Data/PeerSpec.hs
@@ -2,11 +2,11 @@ module Unit.Hoard.Data.PeerSpec (spec_Peer) where
 
 import Network.Socket (SockAddr (..))
 import Test.Hspec
+import Text.Read (read)
 
 import Network.Socket qualified as Socket
 
 import Hoard.Data.Peer (PeerAddress (..), sockAddrToPeerAddress)
-import Text.Read (read)
 
 
 spec_Peer :: Spec

--- a/test/Unit/Hoard/Effects/Cache/SingleflightSpec.hs
+++ b/test/Unit/Hoard/Effects/Cache/SingleflightSpec.hs
@@ -1,7 +1,6 @@
 module Unit.Hoard.Effects.Cache.SingleflightSpec (spec_Singleflight) where
 
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async qualified as Async
 import Effectful (Eff, IOE, Limit (..), Persistence (..), UnliftStrategy (..), runEff, withEffToIO, (:>))
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Exception (catch, throwIO)
@@ -9,13 +8,15 @@ import Effectful.State.Static.Shared (State, modify, runState)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow)
 import Prelude hiding (State, modify, runState)
 
+import Control.Concurrent.Async qualified as Async
+
 import Hoard.Effects.Cache.Singleflight (Singleflight, runSingleflight, updateCache, withCache)
 import Hoard.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
 
 
 -- | Test exception type
 data TestException = TestException Text
-    deriving stock (Show, Eq)
+    deriving stock (Eq, Show)
     deriving anyclass (Exception)
 
 
@@ -40,7 +41,7 @@ compute value = do
 
 
 -- | A slow computation that increments the counter
-slowCompute :: (State Int :> es, IOE :> es) => Int -> Eff es Int
+slowCompute :: (IOE :> es, State Int :> es) => Int -> Eff es Int
 slowCompute value = do
     liftIO $ threadDelay 10000 -- 10ms
     modify @Int (+ 1)

--- a/test/Unit/Hoard/Effects/PublishingSpec.hs
+++ b/test/Unit/Hoard/Effects/PublishingSpec.hs
@@ -1,9 +1,9 @@
 module Unit.Hoard.Effects.PublishingSpec (spec_Pub) where
 
 import Effectful (runPureEff)
+import Effectful.Writer.Static.Shared (runWriter)
 import Test.Hspec (Spec, context, describe, expectationFailure, it, shouldBe)
 
-import Effectful.Writer.Static.Shared (runWriter)
 import Hoard.Effects.Publishing (publish, runPubWriter)
 
 


### PR DESCRIPTION
This also reformats _all_ our Haskell files, since `nix flake check -L` checks formatting, which means this PR would otherwise fail CI.

Depends on #241 