### PR TITLE
fix: use toQuietSnake for component names, remove callsite from logs

### DIFF
--- a/src/Hoard/Component.hs
+++ b/src/Hoard/Component.hs
@@ -7,9 +7,8 @@ module Hoard.Component
     , runSystem
     ) where
 
-import Data.Char (toLower)
 import Effectful (Eff, (:>))
-import Text.Casing (fromHumps, toSnake)
+import Text.Casing (fromHumps, toQuietSnake)
 
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.Log (Log)
@@ -109,4 +108,4 @@ runSystem components = do
 
 
 formatName :: Text -> Text
-formatName = toText . toSnake . fromHumps . fmap toLower . toString
+formatName = toText . toQuietSnake . fromHumps . toString

--- a/src/Hoard/Effects/Log.hs
+++ b/src/Hoard/Effects/Log.hs
@@ -51,7 +51,6 @@ import Effectful.Dispatch.Dynamic (localSeqUnlift, reinterpret, reinterpretWith)
 import Effectful.Reader.Static (Reader, ask, local, runReader)
 import Effectful.TH (makeEffect)
 import Effectful.Writer.Static.Shared (Writer, tell)
-import GHC.Stack (SrcLoc (..))
 import Prelude hiding (Reader, ask, local, runReader)
 
 import Data.ByteString.Char8 qualified as B8
@@ -186,30 +185,11 @@ formatMessage msg =
         [ square $ show msg.severity
         , " "
         , showNamespace msg.namespace
-        , square $ showSourceLoc msg.stack
-        , " "
         , msg.text
         ]
   where
     showNamespace (Namespace "") = ""
     showNamespace (Namespace ns) = square ns <> " "
-
-
-showSourceLoc :: CallStack -> Text
-showSourceLoc cs = showCallStack
-  where
-    showCallStack = case getCallStack cs of
-        [] -> "<unknown loc>"
-        [(name, loc)] -> showLoc name loc
-        (_, loc) : (callerName, _) : _ -> showLoc callerName loc
-    showLoc name src =
-        mconcat
-            [ toText src.srcLocModule
-            , "."
-            , toText name
-            , "#"
-            , show src.srcLocStartLine
-            ]
 
 
 square :: Text -> Text


### PR DESCRIPTION
```
[DEBUG] Setting up component: core
[DEBUG] Setting up component: server
[DEBUG] Setting up component: persistence
[DEBUG] Setting up component: orphan_detection
[DEBUG] Setting up component: monitoring
[DEBUG] Setting up component: peer_manager
[DEBUG] Starting listeners/triggers for component: core
[DEBUG] Starting listeners/triggers for component: server
[DEBUG] Starting listeners/triggers for component: persistence
[DEBUG] Starting listeners/triggers for component: orphan_detection
[DEBUG] Starting listeners/triggers for component: monitoring
[DEBUG] Starting listeners/triggers for component: peer_manager
```