### PR TITLE
refactor: streamline ConnectToPeer implementation

### DIFF
--- a/src/Hoard/Effects/Environment.hs
+++ b/src/Hoard/Effects/Environment.hs
@@ -37,7 +37,6 @@ import Hoard.Types.Environment
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
 import Hoard.Effects.Quota.Config qualified as Quota
 import Hoard.PeerManager.Config qualified as PeerManager
 
@@ -54,7 +53,6 @@ data ConfigFile = ConfigFile
     , maxFileDescriptors :: Maybe Word32
     , cardanoNodeIntegration :: CardanoNodeIntegrationConfig
     , peerManager :: PeerManager.Config
-    , nodeToNode :: NodeToNode.Config
     , quota :: Quota.Config
     }
     deriving stock (Eq, Generic, Show)
@@ -251,7 +249,6 @@ loadEnv eff = withSeqEffToIO \unlift -> withIOManager \ioManager -> unlift do
                 , peerSnapshot
                 , peerManager = configFile.peerManager
                 , cardanoNodeIntegration = configFile.cardanoNodeIntegration
-                , nodeToNode = configFile.nodeToNode
                 , quota = configFile.quota
                 }
         env = Env {config, handles}

--- a/src/Hoard/Types/Environment.hs
+++ b/src/Hoard/Types/Environment.hs
@@ -36,7 +36,6 @@ import Hoard.Types.DBConfig (DBPools (..))
 import Hoard.Types.QuietSnake (QuietSnake (..))
 
 import Hoard.Effects.Log qualified as Log
-import Hoard.Effects.NodeToNode.Config qualified as NodeToNode
 import Hoard.Effects.Quota.Config qualified as Quota
 import Hoard.PeerManager.Config qualified as PeerManager
 
@@ -63,7 +62,6 @@ data Config = Config
     , peerSnapshot :: PeerSnapshotFile
     , peerManager :: PeerManager.Config
     , cardanoNodeIntegration :: CardanoNodeIntegrationConfig
-    , nodeToNode :: NodeToNode.Config
     , quota :: Quota.Config
     }
 

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -125,7 +125,6 @@ runEffectStackTest mkEff = liftIO $ withIOManager $ \ioManager -> do
                 , peerSnapshot = PeerSnapshotFile {bigLedgerPools = []}
                 , cardanoNodeIntegration = cardanoNodeIntegrationCfg
                 , peerManager = def
-                , nodeToNode = def
                 , quota = def
                 }
     let handles =


### PR DESCRIPTION
- Ensure we only check the peer connection for errors, leaving protocol version creation as-is.
- Add meaningful trace spans to gain better insight into the creation of node to node version applications and the connection itself.
- Remove redundant comments.
- Remove redundant events that are better covered by spans.
- Group all main let bindings.