### PR TITLE
feat: add block eviction component

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -46,6 +46,8 @@ import Hoard.PeerManager (CullRequested, PeerDisconnected, PeerRequested)
 import Hoard.PeerManager.Peers (Peers)
 import Hoard.Types.HoardState (HoardState)
 
+import Hoard.BlockEviction qualified as BlockEviction
+import Hoard.BlockEviction.Config qualified as BlockEviction.Config
 import Hoard.Core qualified as Core
 import Hoard.Effects.Conc qualified as Conc
 import Hoard.Effects.NodeToNode.Config qualified as NodeToNode.Config
@@ -71,6 +73,7 @@ main =
         . runHandlesReader
         . Monitoring.runConfig
         . NodeToNode.Config.runProtocolsConfig
+        . BlockEviction.Config.runBlockEvictionConfig
         . runLog
         . runClock
         . runFileSystem
@@ -121,6 +124,7 @@ main =
                 , Server.component
                 , Persistence.component
                 , OrphanDetection.component
+                , BlockEviction.component
                 , Monitoring.component
                 , PeerManager.component
                 ]

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -77,6 +77,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+block_eviction:
+  eviction_interval_seconds: 3600 # 1 hour
+
 # Cardano node integration configuration
 cardano_node_integration:
   ssh_server_alive_interval_seconds: 60

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -97,6 +97,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+block_eviction:
+  eviction_interval_seconds: 3600 # 1 hour
+
 # Cardano node integration configuration
 cardano_node_integration:
   ssh_server_alive_interval_seconds: 60

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -80,6 +80,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+block_eviction:
+  eviction_interval_seconds: 3600 # 1 hour
+
 # Cardano node integration configuration
 cardano_node_integration:
   ssh_server_alive_interval_seconds: 60

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -79,6 +79,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+block_eviction:
+  eviction_interval_seconds: 3600 # 1 hour
+
 # Cardano node integration configuration
 cardano_node_integration:
   ssh_server_alive_interval_seconds: 60

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -17,6 +17,8 @@ library
   exposed-modules:
       Hoard.API
       Hoard.API.Violations
+      Hoard.BlockEviction
+      Hoard.BlockEviction.Config
       Hoard.Bootstrap
       Hoard.Collector
       Hoard.Component
@@ -300,6 +302,7 @@ test-suite hoard-test
       Hoard.TestHelpers
       Hoard.TestHelpers.Database
       Integration.DBEffects
+      Integration.Hoard.DB.BlockEvictionSpec
       Integration.Hoard.DB.BlockPersistenceSpec
       Integration.Hoard.DB.HeaderPersistenceSpec
       Integration.Hoard.DB.PeerPersistenceSpec

--- a/src/Hoard/BlockEviction.hs
+++ b/src/Hoard/BlockEviction.hs
@@ -1,0 +1,35 @@
+module Hoard.BlockEviction (component) where
+
+import Effectful ((:>))
+import Effectful.Concurrent (Concurrent)
+import Effectful.Reader.Static (Reader, ask)
+import Prelude hiding (Reader, ask)
+
+import Hoard.BlockEviction.Config (Config (..))
+import Hoard.Component (Component (..), defaultComponent)
+import Hoard.Effects.BlockRepo (BlockRepo)
+import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
+import Hoard.Triggers (every)
+
+import Hoard.Effects.BlockRepo qualified as BlockRepo
+
+
+component
+    :: ( BlockRepo :> es
+       , Concurrent :> es
+       , Reader Config :> es
+       , Tracing :> es
+       )
+    => Component es
+component =
+    defaultComponent
+        { name = "BlockEviction"
+        , triggers = do
+            cfg <- ask
+            let interval = cfg.evictionIntervalSeconds
+            pure
+                [ every interval $ withSpan "block_eviction.evict" $ do
+                    count <- BlockRepo.evictBlocks
+                    addEvent "blocks_evicted" [("evicted.count", show count)]
+                ]
+        }

--- a/src/Hoard/BlockEviction/Config.hs
+++ b/src/Hoard/BlockEviction/Config.hs
@@ -1,0 +1,43 @@
+module Hoard.BlockEviction.Config
+    ( Config (..)
+    , runBlockEvictionConfig
+    ) where
+
+import Data.Aeson (FromJSON)
+import Data.Default (Default (..))
+import Effectful (Eff, IOE, (:>))
+import Effectful.Reader.Static (Reader, ask, runReader)
+import Prelude hiding (Reader, ask, runReader)
+
+import Hoard.Effects.ConfigPath (ConfigPath, loadYaml)
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+
+-- | Configuration for block eviction
+data Config = Config
+    { evictionIntervalSeconds :: !Int
+    -- ^ How often the eviction trigger runs (in seconds).
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake Config
+
+
+instance Default Config where
+    def =
+        Config
+            { evictionIntervalSeconds = 3600 -- 1 hour
+            }
+
+
+data ConfigFile = ConfigFile
+    { blockEviction :: Config
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake ConfigFile
+
+
+runBlockEvictionConfig :: (IOE :> es, Reader ConfigPath :> es) => Eff (Reader Config : es) a -> Eff es a
+runBlockEvictionConfig eff = do
+    configPath <- ask
+    configFile <- loadYaml @ConfigFile configPath
+    runReader configFile.blockEviction eff

--- a/test/Integration/Hoard/DB/BlockEvictionSpec.hs
+++ b/test/Integration/Hoard/DB/BlockEvictionSpec.hs
@@ -1,0 +1,185 @@
+module Integration.Hoard.DB.BlockEvictionSpec (spec_BlockEviction) where
+
+import Data.Time (UTCTime (..))
+import Effectful (runEff, runPureEff)
+import Effectful.Concurrent (runConcurrent)
+import Effectful.Error.Static (runErrorNoCallStack)
+import Effectful.Reader.Static (runReader)
+import Ouroboros.Consensus.Block (GetHeader (getHeader))
+import Ouroboros.Consensus.Cardano.Block
+    ( HardForkBlock
+        ( BlockAllegra
+        , BlockAlonzo
+        , BlockBabbage
+        , BlockConway
+        , BlockMary
+        , BlockShelley
+        )
+    )
+import Relude.Unsafe (fromJust, head, read, (!!))
+import Test.Consensus.Shelley.Examples
+    ( examplesAllegra
+    , examplesAlonzo
+    , examplesBabbage
+    , examplesConway
+    , examplesMary
+    , examplesShelley
+    )
+import Test.Hspec
+import Test.Util.Serialisation.Examples (Examples (..))
+import Prelude hiding (evalState, head, runReader)
+
+import Hoard.Data.Block (Block (..))
+import Hoard.Data.BlockHash (BlockHash, blockHashFromHeader)
+import Hoard.Data.PoolID (PoolID (..))
+import Hoard.Effects.BlockRepo (classifyBlock, evictBlocks, insertBlocks, runBlockRepo)
+import Hoard.Effects.Clock (runClock)
+import Hoard.Effects.DBRead (runDBRead)
+import Hoard.Effects.DBWrite (runDBWrite)
+import Hoard.Effects.Monitoring.Metrics (runMetricsNoOp)
+import Hoard.Effects.Monitoring.Tracing (runTracingNoOp)
+import Hoard.Effects.Verifier (Validity (Valid), Verified)
+import Hoard.OrphanDetection.Data (BlockClassification (..))
+import Hoard.TestHelpers.Database (TestConfig (..), withCleanTestDatabase)
+import Hoard.Types.Cardano (CardanoBlock)
+
+import Hoard.Effects.Log qualified as Log
+import Hoard.Effects.Verifier qualified as Verifier
+
+
+spec_BlockEviction :: Spec
+spec_BlockEviction = do
+    let runDB config action =
+            runEff
+                . Log.runLogNoOp
+                . runErrorNoCallStack @Text
+                . runReader config.pools
+                . runMetricsNoOp
+                . runTracingNoOp
+                . runClock
+                . runDBRead
+                . runDBWrite
+                . runConcurrent
+                . runBlockRepo
+                $ action
+
+    withCleanTestDatabase $ describe "Block eviction (database)" $ do
+        it "evicts nothing when there are no blocks" $ \config -> do
+            result <- runDB config evictBlocks
+            result `shouldBe` Right 0
+
+        it "evicts all canonical blocks when there are no orphans" $ \config -> do
+            -- Insert 3 canonical blocks at different slots (no orphans)
+            let blocks = [mkTestBlock 1, mkTestBlock 2, mkTestBlock 3]
+            result <- runDB config $ do
+                insertBlocks blocks
+                classifyBlock (blockHash 1) Canonical epoch
+                classifyBlock (blockHash 2) Canonical epoch
+                classifyBlock (blockHash 3) Canonical epoch
+                evictBlocks
+            result `shouldBe` Right 3
+
+        it "keeps canonical block that has an orphan at the same slot" $ \config -> do
+            -- slot 10: canonical + orphan (battle) → keep both
+            -- slot 11: canonical only → evict
+            let canonical10 = mkTestBlock 10
+                orphan10 = mkTestBlock 20 -- different block hash, same slot via classification
+                canonical11 = mkTestBlock 11
+            result <- runDB config $ do
+                insertBlocks [canonical10, orphan10, canonical11]
+                -- Classify canonical10 and orphan10 at slot 10 (same slot number in the block)
+                classifyBlock (blockHash 10) Canonical epoch
+                -- We can't change slotNumber, so test the logic via the actual slot fields:
+                -- orphan10 has slotNumber=20, canonical10 has slotNumber=10
+                -- They're at different slots, so this tests the "no orphan at same slot" path
+                classifyBlock (blockHash 20) Orphaned epoch
+                classifyBlock (blockHash 11) Canonical epoch
+                evictBlocks
+            -- canonical10 (slot 10) - no orphan at slot 10 → evicted
+            -- orphan10 (slot 20) - orphan → kept
+            -- canonical11 (slot 11) - no orphan at slot 11 → evicted
+            result `shouldBe` Right 2
+
+        it "keeps canonical block when orphan is at the same slot" $ \config -> do
+            -- Use blocks with the same slot number by setting slotNumber directly
+            -- mkTestBlockAtSlot creates blocks with a specific slot
+            let canonicalBlock = mkTestBlockAtSlot 0 100 -- hash from index 0, slot 100
+                orphanBlock = mkTestBlockAtSlot 1 100 -- hash from index 1, same slot 100
+            result <- runDB config $ do
+                insertBlocks [canonicalBlock, orphanBlock]
+                classifyBlock (blockHash' canonicalBlock) Canonical epoch
+                classifyBlock (blockHash' orphanBlock) Orphaned epoch
+                evictBlocks
+            -- Both blocks are at slot 100: canonical has orphan at same slot → kept
+            -- Orphan is always kept
+            -- So 0 blocks evicted
+            result `shouldBe` Right 0
+
+        it "does not evict unclassified blocks" $ \config -> do
+            let blocks = [mkTestBlock 1, mkTestBlock 2]
+            result <- runDB config $ do
+                insertBlocks blocks
+                -- Don't classify them
+                evictBlocks
+            result `shouldBe` Right 0
+
+        it "does not evict orphaned blocks" $ \config -> do
+            let blocks = [mkTestBlock 1, mkTestBlock 2]
+            result <- runDB config $ do
+                insertBlocks blocks
+                classifyBlock (blockHash 1) Orphaned epoch
+                classifyBlock (blockHash 2) Orphaned epoch
+                evictBlocks
+            result `shouldBe` Right 0
+
+
+-- | Block hash for a test block created with mkTestBlock n
+blockHash :: Int64 -> BlockHash
+blockHash n = (.hash) $ Verifier.getVerified (mkTestBlock n)
+
+
+-- | Block hash from a verified block
+blockHash' :: Verified Valid Block -> BlockHash
+blockHash' = (.hash) . Verifier.getVerified
+
+
+-- | Create a test block with slot number = n (and hash derived from n mod examples)
+mkTestBlock :: Int64 -> Verified Valid Block
+mkTestBlock n = mkTestBlockAtSlot (fromIntegral n) n
+
+
+-- | Create a test block using the nth example cardano block, at the given slot number
+mkTestBlockAtSlot :: Int -> Int64 -> Verified Valid Block
+mkTestBlockAtSlot exampleIdx slotNumber =
+    let cardanoBlock = exampleBlocks !! (exampleIdx `mod` length exampleBlocks)
+        header = getHeader cardanoBlock
+    in  runPureEff
+            $ Verifier.runAllValidVerifier
+            $ fmap (fromJust . rightToMaybe)
+            $ Verifier.verifyBlock
+            $ Block
+                { hash = blockHashFromHeader header
+                , slotNumber = slotNumber
+                , poolId = PoolID "test-pool"
+                , blockData = cardanoBlock
+                , validationStatus = ""
+                , validationReason = ""
+                , firstSeen = epoch
+                , classification = Nothing
+                , classifiedAt = Nothing
+                }
+
+
+exampleBlocks :: [CardanoBlock]
+exampleBlocks =
+    [ BlockShelley $ snd $ Relude.Unsafe.head examplesShelley.exampleBlock
+    , BlockAllegra $ snd $ Relude.Unsafe.head examplesAllegra.exampleBlock
+    , BlockMary $ snd $ Relude.Unsafe.head examplesMary.exampleBlock
+    , BlockAlonzo $ snd $ Relude.Unsafe.head examplesAlonzo.exampleBlock
+    , BlockBabbage $ snd $ Relude.Unsafe.head examplesBabbage.exampleBlock
+    , BlockConway $ snd $ Relude.Unsafe.head examplesConway.exampleBlock
+    ]
+
+
+epoch :: UTCTime
+epoch = UTCTime (read "1970-01-01") 0


### PR DESCRIPTION
:bulb:  Review commit by commit.

Periodically evicts uninteresting canonical blocks from the database and cache. For now a canonical block is considered uninteresting when no orphaned block exists at the same slot (i.e. it won the slot uncontested). Contested canonical blocks and all orphaned blocks are kept.

- Add `BlockEviction` component with configurable trigger interval
- Add `EvictBlocks` operation to `BlockRepo` with DB transaction + cache invalidation via `Singleflight.removeFromCache`
- Add `RemoveFromCache` to `Singleflight` cache effect
- Add `block_eviction` config section to all environment config files
- Add integration tests covering eviction logic

Also slightly change the API endpoint to include the canonical block if present.