### PR TITLE
feat: add Sentry component

### DIFF
--- a/db/deploy/008_create_peer_notes_table.sql
+++ b/db/deploy/008_create_peer_notes_table.sql
@@ -1,0 +1,15 @@
+-- Deploy hoard:008_create_peer_notes_table to pg
+
+BEGIN;
+
+CREATE TYPE hoard.note_type AS ENUM ('Adversarial');
+
+CREATE TABLE hoard.peer_notes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  peer_id UUID NOT NULL REFERENCES hoard.peers(id) ON DELETE CASCADE,
+  note_type hoard.note_type NOT NULL,
+  note TEXT NOT NULL,
+  noted_at TIMESTAMPTZ NOT NULL
+);
+
+COMMIT;

--- a/db/revert/008_peer_notes_table.sql
+++ b/db/revert/008_peer_notes_table.sql
@@ -1,0 +1,8 @@
+-- Revert hoard:008_create_peer_notes_table from pg
+
+BEGIN;
+
+DROP TABLE hoard.peer_notes;
+DROP TYPE hoard.note_type;
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -9,3 +9,4 @@
 005_create_headers_table 2025-12-09T00:00:00Z Christian Georgii <christian.georgii@moduscreate.com> # Add headers table for chain sync protocol headers
 006_create_hoard_state_table 2026-01-19T18:30:23Z rednaz <rednaz@nixos2> # Add hoard_state table for persisting parts of the HoardState across restarts
 007_add_block_classification [004_create_blocks_table] 2026-01-28T00:00:00Z Christian Georgii <christian.georgii@moduscreate.com> # Add classification for orphan detection
+008_create_peer_notes_table 2026-02-20T10:30:13Z Victor Nascimento Bakke <gipphe@argon> # Create table to track notable information about peers

--- a/db/verify/008_create_peer_notes_table.sql
+++ b/db/verify/008_create_peer_notes_table.sql
@@ -1,0 +1,20 @@
+-- Verify hoard:008_create_peer_notes_table on pg
+
+BEGIN;
+
+SELECT
+    id,
+    peer_id,
+    note_type,
+    note,
+    noted_at
+FROM hoard.peer_notes
+WHERE FALSE;
+
+SELECT 1/COUNT(*) FROM information_schema.table_constraints
+WHERE constraint_schema = 'hoard'
+  AND table_name = 'peer_notes'
+  AND constraint_type = 'FOREIGN KEY'
+  AND constraint_name = 'peer_notes_peer_id_fkey';
+
+ROLLBACK;

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -32,12 +32,14 @@ library
       Hoard.Data.Header
       Hoard.Data.ID
       Hoard.Data.Peer
+      Hoard.Data.PeerNote
       Hoard.Data.PoolID
       Hoard.DB.Schema
       Hoard.DB.Schemas.Blocks
       Hoard.DB.Schemas.HeaderReceipts
       Hoard.DB.Schemas.Headers
       Hoard.DB.Schemas.HoardState
+      Hoard.DB.Schemas.PeerNotes
       Hoard.DB.Schemas.Peers
       Hoard.Effects
       Hoard.Effects.BlockRepo
@@ -66,6 +68,7 @@ library
       Hoard.Effects.NodeToNode.KeepAlive
       Hoard.Effects.NodeToNode.PeerSharing
       Hoard.Effects.Options
+      Hoard.Effects.PeerNoteRepo
       Hoard.Effects.PeerRepo
       Hoard.Effects.Publishing
       Hoard.Effects.Quota
@@ -91,6 +94,7 @@ library
       Hoard.PeerManager.Config
       Hoard.PeerManager.Peers
       Hoard.Persistence
+      Hoard.Sentry
       Hoard.Server
       Hoard.Server.Config
       Hoard.Triggers

--- a/src/Hoard/DB/Schemas/PeerNotes.hs
+++ b/src/Hoard/DB/Schemas/PeerNotes.hs
@@ -1,0 +1,67 @@
+module Hoard.DB.Schemas.PeerNotes
+    ( Row (..)
+    , schema
+    , peerNoteFromRow
+    , rowFromPeerNote
+    )
+where
+
+import Data.Time (UTCTime)
+import Rel8
+    ( Column
+    , Expr
+    , Name
+    , Rel8able
+    , Result
+    , TableSchema
+    , lit
+    )
+
+import Hoard.DB.Schema (mkSchema)
+import Hoard.Data.ID (ID)
+import Hoard.Data.Peer (Peer (..))
+import Hoard.Data.PeerNote (NoteType, PeerNote (..))
+
+
+data Row f = Row
+    { id :: Column f (ID PeerNote)
+    , peerId :: Column f (ID Peer)
+    , noteType :: Column f NoteType
+    , note :: Column f Text
+    , notedAt :: Column f UTCTime
+    }
+    deriving stock (Generic)
+    deriving anyclass (Rel8able)
+
+
+deriving instance Eq (Row Result)
+
+
+deriving instance Show (Row Result)
+
+
+schema :: TableSchema (Row Name)
+schema = mkSchema "peer_notes"
+
+
+peerNoteFromRow :: Row Result -> PeerNote
+peerNoteFromRow row =
+    PeerNote
+        { id = row.id
+        , peerId = row.peerId
+        , noteType = row.noteType
+        , note = row.note
+        , notedAt = row.notedAt
+        }
+
+
+-- | Convert a Peer domain type to a database row
+rowFromPeerNote :: PeerNote -> Row Expr
+rowFromPeerNote note =
+    Row
+        { id = lit note.id
+        , peerId = lit note.peerId
+        , noteType = lit note.noteType
+        , note = lit note.note
+        , notedAt = lit note.notedAt
+        }

--- a/src/Hoard/Data/BlockHash.hs
+++ b/src/Hoard/Data/BlockHash.hs
@@ -19,7 +19,7 @@ import Hoard.Types.Cardano (CardanoBlock, CardanoHeader)
 -- | Newtype wrapper for block hash
 newtype BlockHash = BlockHash Text
     deriving stock (Eq, Generic, Ord, Show)
-    deriving newtype (DBEq, DBOrd, DBType, FromJSON, ToJSON)
+    deriving newtype (DBEq, DBOrd, DBType, FromJSON, Hashable, ToJSON)
 
 
 blockHashFromHeader :: CardanoHeader -> BlockHash

--- a/src/Hoard/Data/PeerNote.hs
+++ b/src/Hoard/Data/PeerNote.hs
@@ -1,0 +1,31 @@
+module Hoard.Data.PeerNote
+    ( PeerNote (..)
+    , NoteType (..)
+    ) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Time (UTCTime)
+import Rel8 (DBEq, DBType, ReadShow (..))
+
+import Hoard.Data.ID (ID)
+import Hoard.Data.Peer (Peer)
+import Hoard.Types.JsonReadShow (JsonReadShow (..))
+
+
+-- | A given note about a peer.
+data PeerNote = PeerNote
+    { id :: ID PeerNote
+    , peerId :: ID Peer
+    , noteType :: NoteType
+    , note :: Text
+    , notedAt :: UTCTime
+    }
+
+
+-- | Potential forms of notes about peers.
+data NoteType
+    = Adversarial
+    deriving (Eq, Generic, Ord)
+    deriving (Read, Show)
+    deriving (FromJSON, ToJSON) via JsonReadShow NoteType
+    deriving (DBEq, DBType) via ReadShow NoteType

--- a/src/Hoard/Effects/PeerNoteRepo.hs
+++ b/src/Hoard/Effects/PeerNoteRepo.hs
@@ -1,0 +1,75 @@
+module Hoard.Effects.PeerNoteRepo
+    ( PeerNoteRepo (..)
+    , saveNote
+    , runPeerNoteRepo
+    , runPeerNoteRepoState
+    ) where
+
+import Effectful (Eff, Effect, (:>))
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.State.Static.Shared (State, modify)
+import Effectful.TH (makeEffect)
+import Rel8 (lit)
+import Prelude hiding (State, modify)
+
+import Data.UUID qualified as UUID
+import Hasql.Transaction qualified as TX
+import Rel8 qualified
+import Rel8.Expr.Time qualified
+
+import Hoard.Data.ID (ID (..))
+import Hoard.Data.Peer (Peer)
+import Hoard.Data.PeerNote (NoteType, PeerNote (..))
+import Hoard.Effects.Clock (Clock)
+import Hoard.Effects.DBWrite (DBWrite, runTransaction)
+
+import Hoard.DB.Schemas.PeerNotes qualified as PeerNotes
+import Hoard.Effects.Clock qualified as Clock
+
+
+data PeerNoteRepo :: Effect where
+    SaveNote :: ID Peer -> NoteType -> Text -> PeerNoteRepo m PeerNote
+
+
+makeEffect ''PeerNoteRepo
+
+
+runPeerNoteRepo :: (DBWrite :> es) => Eff (PeerNoteRepo : es) a -> Eff es a
+runPeerNoteRepo = interpret_ \case
+    SaveNote peerId noteType note -> do
+        runTransaction "save-note"
+            . fmap PeerNotes.peerNoteFromRow
+            . TX.statement ()
+            . Rel8.run1
+            $ Rel8.insert
+                Rel8.Insert
+                    { into = PeerNotes.schema
+                    , rows =
+                        Rel8.values
+                            [ PeerNotes.Row
+                                { PeerNotes.id = Rel8.unsafeDefault
+                                , PeerNotes.peerId = lit peerId
+                                , PeerNotes.noteType = lit noteType
+                                , PeerNotes.note = lit note
+                                , PeerNotes.notedAt = Rel8.Expr.Time.now
+                                }
+                            ]
+                    , onConflict = Rel8.Abort
+                    , returning = Rel8.Returning Prelude.id
+                    }
+
+
+runPeerNoteRepoState :: (Clock :> es, State [PeerNote] :> es) => Eff (PeerNoteRepo : es) a -> Eff es a
+runPeerNoteRepoState = interpret_ \case
+    SaveNote peerId noteType note -> do
+        notedAt <- Clock.currentTime
+        let peerNote =
+                PeerNote
+                    { id = ID $ UUID.fromWords64 0 0
+                    , peerId
+                    , noteType
+                    , note
+                    , notedAt
+                    }
+        modify (peerNote :)
+        pure peerNote

--- a/src/Hoard/Events/BlockFetch.hs
+++ b/src/Hoard/Events/BlockFetch.hs
@@ -7,6 +7,7 @@ module Hoard.Events.BlockFetch
     ) where
 
 import Data.Time (UTCTime)
+import Data.UUID (UUID)
 import Prelude hiding (Reader, State, ask, evalState, get, modify, runReader)
 
 import Hoard.Data.Peer (Peer (..))
@@ -37,6 +38,7 @@ data BlockReceived = BlockReceived
     { peer :: Peer
     , timestamp :: UTCTime
     , block :: CardanoBlock
+    , requestId :: UUID
     }
     deriving (Typeable)
 

--- a/src/Hoard/Sentry.hs
+++ b/src/Hoard/Sentry.hs
@@ -1,0 +1,172 @@
+module Hoard.Sentry
+    ( component
+    , DuplicateBlockKey (..)
+    , DuplicateBlocks (..)
+    , AdversarialBehavior (..)
+    , AdversarialSeverity (..)
+    , runDuplicateBlocksState
+
+      -- * Config
+    , Config (..)
+    , DuplicateBlocksConfig (..)
+    ) where
+
+import Data.Aeson (FromJSON)
+import Data.Default (Default (..))
+import Data.Time (UTCTime)
+import Data.UUID (UUID)
+import Effectful (Eff, (:>))
+import Effectful.Concurrent.STM (Concurrent, atomically)
+import Effectful.Reader.Static (Reader, asks)
+import Effectful.State.Static.Shared (State, evalState, gets)
+import Ouroboros.Consensus.Block (getHeader)
+import StmContainers.Map (Map)
+import Prelude hiding (Map, Reader, State, asks, atomically, evalState, gets)
+
+import StmContainers.Map qualified as Map
+
+import Hoard.Component (Component (..), defaultComponent)
+import Hoard.Data.BlockHash (BlockHash, blockHashFromHeader)
+import Hoard.Data.ID (ID)
+import Hoard.Data.Peer (Peer (..))
+import Hoard.Effects.Clock (Clock)
+import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, withSpan)
+import Hoard.Effects.Publishing (Pub, Sub, publish)
+import Hoard.Events.BlockFetch (BlockReceived (..))
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+import Hoard.Effects.Clock qualified as Clock
+import Hoard.Effects.Publishing qualified as Sub
+
+
+component
+    :: ( Clock :> es
+       , Concurrent :> es
+       , Pub AdversarialBehavior :> es
+       , Reader Config :> es
+       , State DuplicateBlocks :> es
+       , Sub BlockReceived :> es
+       , Tracing :> es
+       )
+    => Component es
+component =
+    defaultComponent
+        { name = "Sentry"
+        , listeners =
+            pure
+                [ Sub.listen duplicateBlockGuard
+                ]
+        }
+
+
+newtype DuplicateBlocks = DuplicateBlocks
+    { duplicateBlocks :: Map (ID Peer, UUID, BlockHash) Word
+    }
+
+
+runDuplicateBlocksState :: (Concurrent :> es) => Eff (State DuplicateBlocks : es) a -> Eff es a
+runDuplicateBlocksState eff = do
+    m <- atomically Map.new
+    evalState (DuplicateBlocks m) eff
+
+
+duplicateBlockGuard
+    :: ( Clock :> es
+       , Concurrent :> es
+       , Pub AdversarialBehavior :> es
+       , Reader Config :> es
+       , State DuplicateBlocks :> es
+       , Tracing :> es
+       )
+    => BlockReceived -> Eff es ()
+duplicateBlockGuard event = withSpan "sentry.duplicate_block_guard" do
+    addAttribute "peer.id" $ show event.peer.id
+    addAttribute "peer.address" $ show event.peer.address
+    addAttribute "request.id" $ show event.requestId
+    let blockHash = blockHashFromHeader $ getHeader event.block
+    m <- gets (.duplicateBlocks)
+    let key = (event.peer.id, event.requestId, blockHash)
+    c <- atomically do
+        count <- fromMaybe 0 <$> Map.lookup key m
+        let newCount = count + 1
+        Map.insert newCount key m
+        pure newCount
+    duplicateConfig <- asks (.duplicateBlocks)
+    timestamp <- Clock.currentTime
+    if
+        | c > duplicateConfig.criticalThreshold -> do
+            addAttribute "result" "warning"
+            publish
+                $ AdversarialBehavior
+                    { timestamp
+                    , peer = event.peer
+                    , description = "exceeded duplicate block critical threshold"
+                    , severity = Critical
+                    }
+        | c > duplicateConfig.warningThreshold -> do
+            addAttribute "result" "critical"
+            publish
+                $ AdversarialBehavior
+                    { timestamp
+                    , peer = event.peer
+                    , description = "exceeded duplicate block warning threshold"
+                    , severity = Minor
+                    }
+        | otherwise -> do
+            addAttribute "result" "none"
+            pure ()
+
+
+data DuplicateBlockKey = DuplicateBlockKey
+    { peerId :: ID Peer
+    , hash :: BlockHash
+    , requestId :: UUID
+    }
+    deriving (Hashable)
+    deriving stock (Eq, Generic, Ord, Show)
+
+
+data AdversarialSeverity
+    = Minor
+    | Critical
+    deriving (Bounded, Enum, Eq, Show)
+
+
+data AdversarialBehavior = AdversarialBehavior
+    { timestamp :: UTCTime
+    , peer :: Peer
+    , severity :: AdversarialSeverity
+    , description :: Text
+    }
+
+
+data Config = Config
+    { duplicateBlocks :: DuplicateBlocksConfig
+    }
+    deriving (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake Config
+
+
+instance Default Config where
+    def =
+        Config
+            { duplicateBlocks = def
+            }
+
+
+data DuplicateBlocksConfig = DuplicateBlocksConfig
+    { warningThreshold :: Word
+    -- ^ Threshold before the peer is considered to exhibit adversarial behavior.
+    , criticalThreshold :: Word
+    -- ^ Threshold before the peer is considered adequately adversarial to warrant major action.
+    }
+    deriving (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake DuplicateBlocksConfig
+
+
+instance Default DuplicateBlocksConfig where
+    def =
+        DuplicateBlocksConfig
+            { warningThreshold = 1
+            , criticalThreshold = 20
+            }


### PR DESCRIPTION
- Add Sentry component that monitors `BlockReceived` events and detects duplicate blocks from the same peer using the existing Quota effect. When the duplicate threshold is exceeded, it publishes a `PeerMarkedAsMalicious` event.
- Add `peer_notes` database table to persistent notes about peers, with a `note_type` enum (currently just `'Malicious'`). `peer_notes` is mostly intended to be actionable information for the Hoarding node, such as information on the malicious behavior of a node (in which case we might want to treat it differently) and such.
- Add `PeerNoteRepo` effect for saving peer notes to the database, along with an in-memory State-based interpreter for testing.
- React to malicious peer events in `PeerManager`. Will terminate the connection to the flagged peer when the peer is marked as malicious.
- React to malicious peer events in Persistence. Simply stores a `peer_note` for the peer about its malicious activity.

This is mostly a POC of sorts of how a `Sentry` component of ours might work. The intention behind it is to protect the Hoarding node itself from malicious behavior, especially when it comes to directed attacks towards the Hoarding node.