### PR TITLE
refactor: return slot disputes from violations API

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -16,6 +16,7 @@ build-type:    Simple
 library
   exposed-modules:
       Hoard.API
+      Hoard.API.Data.BlockViolation
       Hoard.API.Violations
       Hoard.BlockEviction
       Hoard.BlockEviction.Config
@@ -26,7 +27,6 @@ library
       Hoard.Core
       Hoard.Data.Block
       Hoard.Data.BlockHash
-      Hoard.Data.BlockViolation
       Hoard.Data.Eras
       Hoard.Data.Header
       Hoard.Data.ID

--- a/src/Hoard/API/Violations.hs
+++ b/src/Hoard/API/Violations.hs
@@ -6,10 +6,9 @@ module Hoard.API.Violations
 import Effectful (Eff)
 import Servant (Get, JSON, QueryParam, type (:-), type (:>))
 
-import Hoard.Data.BlockViolation (BlockViolation)
+import Hoard.API.Data.BlockViolation (SlotDispute)
 import Hoard.Effects ((::>))
 import Hoard.Effects.BlockRepo (BlockRepo)
-import Hoard.OrphanDetection.Data (BlockClassification)
 
 import Hoard.Effects.BlockRepo qualified as BlockRepo
 
@@ -18,12 +17,11 @@ import Hoard.Effects.BlockRepo qualified as BlockRepo
 type ViolationsAPI mode =
     mode
         :- "violations"
-            :> QueryParam "classification" BlockClassification
             :> QueryParam "minSlot" Int64
             :> QueryParam "maxSlot" Int64
-            :> Get '[JSON] [BlockViolation]
+            :> Get '[JSON] [SlotDispute]
 
 
 -- | Handler for violations endpoint
-violationsHandler :: (BlockRepo ::> es) => Maybe BlockClassification -> Maybe Int64 -> Maybe Int64 -> Eff es [BlockViolation]
+violationsHandler :: (BlockRepo ::> es) => Maybe Int64 -> Maybe Int64 -> Eff es [SlotDispute]
 violationsHandler = BlockRepo.getViolations

--- a/test/Integration/Hoard/IntegrationSpec.hs
+++ b/test/Integration/Hoard/IntegrationSpec.hs
@@ -3,7 +3,6 @@ module Integration.Hoard.IntegrationSpec (spec_ViolationsIntegration) where
 import Test.Hspec
 
 import Hoard.API (Routes (..))
-import Hoard.OrphanDetection.Data (BlockClassification (..))
 import Hoard.TestHelpers (client, withEffectStackServer)
 
 
@@ -14,33 +13,26 @@ spec_ViolationsIntegration = describe "Violations API Integration Tests" $ do
             $ void @IO
             $ withEffectStackServer
             $ \_ runClient -> do
-                result <- runClient (client.violations Nothing Nothing Nothing)
-                liftIO $ result `shouldSatisfy` isRight
-
-        it "accepts classification query parameter"
-            $ void @IO
-            $ withEffectStackServer
-            $ \_ runClient -> do
-                result <- runClient (client.violations (Just Canonical) Nothing Nothing)
+                result <- runClient (client.violations Nothing Nothing)
                 liftIO $ result `shouldSatisfy` isRight
 
         it "accepts minSlot query parameter"
             $ void @IO
             $ withEffectStackServer
             $ \_ runClient -> do
-                result <- runClient (client.violations Nothing (Just 1000) Nothing)
+                result <- runClient (client.violations (Just 1000) Nothing)
                 liftIO $ result `shouldSatisfy` isRight
 
         it "accepts maxSlot query parameter"
             $ void @IO
             $ withEffectStackServer
             $ \_ runClient -> do
-                result <- runClient (client.violations Nothing Nothing (Just 2000))
+                result <- runClient (client.violations Nothing (Just 2000))
                 liftIO $ result `shouldSatisfy` isRight
 
-        it "accepts all query parameters together"
+        it "accepts both slot parameters"
             $ void @IO
             $ withEffectStackServer
             $ \_ runClient -> do
-                result <- runClient (client.violations (Just Canonical) (Just 1000) (Just 2000))
+                result <- runClient (client.violations (Just 1000) (Just 2000))
                 liftIO $ result `shouldSatisfy` isRight


### PR DESCRIPTION
- Move `BlockViolation` module to `Hoard.API.Data` namespace
- Add `SlotDispute` type grouping orphans with their canonical winner per slot
- Add `groupIntoDisputes` to fold flat violations into per-slot disputes
- Drop classification query param; filter at DB level instead (only slots with orphans)

Depends on #268 
