### PR TITLE
refactor: use ToAttribute class in addAttribute and addEvent

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -11,8 +11,6 @@ import Prelude hiding (evalState)
 
 import Hoard.Component (runSystem)
 import Hoard.Control.Exception (runErrorThrowing)
-import Hoard.Data.ID (ID)
-import Hoard.Data.Peer (Peer)
 import Hoard.Effects.BlockRepo (runBlockRepo)
 import Hoard.Effects.Chan (runChan)
 import Hoard.Effects.Clock (runClock)
@@ -44,6 +42,7 @@ import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefresh
 import Hoard.Monitoring (Poll)
 import Hoard.PeerManager (CullRequested, PeerDisconnected, PeerRequested)
 import Hoard.PeerManager.Peers (Peers)
+import Hoard.Persistence (PeerSlotKey)
 import Hoard.Types.HoardState (HoardState)
 
 import Hoard.BlockEviction qualified as BlockEviction
@@ -100,7 +99,7 @@ main =
         . evalState @Peers def
         . Sentry.runDuplicateBlocksState
         . runTracingFromConfig
-        . runQuota @(ID Peer, Int64) 1
+        . runQuota @PeerSlotKey 1
         . runPubSub @ChainSyncStarted
         . runPubSub @ChainSyncIntersectionFound
         . runPubSub @RollBackward

--- a/src/Hoard/BlockEviction.hs
+++ b/src/Hoard/BlockEviction.hs
@@ -8,7 +8,7 @@ import Prelude hiding (Reader, ask)
 import Hoard.BlockEviction.Config (Config (..))
 import Hoard.Component (Component (..), defaultComponent)
 import Hoard.Effects.BlockRepo (BlockRepo)
-import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
+import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, withSpan)
 import Hoard.Triggers (every)
 
 import Hoard.Effects.BlockRepo qualified as BlockRepo
@@ -30,6 +30,6 @@ component =
             pure
                 [ every interval $ withSpan "block_eviction.evict" $ do
                     count <- BlockRepo.evictBlocks
-                    addEvent "blocks_evicted" [("evicted.count", show count)]
+                    addAttribute "evicted.count" count
                 ]
         }

--- a/src/Hoard/Core.hs
+++ b/src/Hoard/Core.hs
@@ -66,7 +66,7 @@ component =
         , start = do
             -- Trigger initial immutable tip refresh now that listeners are registered
             publish ImmutableTipRefreshTriggered
-            addEvent "initial_tip_refresh_triggered" []
+            addEvent @Int "initial_tip_refresh_triggered" []
         }
 
 
@@ -122,4 +122,8 @@ setFileDescriptorLimit = withSpan "set_file_descriptor_limit" $ do
     -- Only update if different from current
     when (newSoftLimit /= softLimit) $ do
         liftIO $ setResourceLimit ResourceOpenFiles ResourceLimits {softLimit = newSoftLimit, hardLimit}
-        addEvent "file_descriptor_limit_updated" [("new_soft_limit", show newSoftLimit), ("old_soft_limit", show softLimit)]
+        addEvent @Text
+            "file_descriptor_limit_updated"
+            [ ("new_soft_limit", show newSoftLimit)
+            , ("old_soft_limit", show softLimit)
+            ]

--- a/src/Hoard/Data/BlockHash.hs
+++ b/src/Hoard/Data/BlockHash.hs
@@ -13,13 +13,15 @@ import Rel8 (DBEq, DBOrd, DBType)
 import Data.ByteString.Base16 qualified as B16
 import Data.Text.Encoding qualified as Text
 
+import Hoard.Effects.Monitoring.Tracing (ToAttribute, ToAttributeShow (..))
 import Hoard.Types.Cardano (CardanoBlock, CardanoHeader)
 
 
 -- | Newtype wrapper for block hash
 newtype BlockHash = BlockHash Text
     deriving stock (Eq, Generic, Ord, Show)
-    deriving newtype (DBEq, DBOrd, DBType, FromJSON, Hashable, ToJSON)
+    deriving (DBEq, DBOrd, DBType, FromJSON, Hashable, ToJSON) via Text
+    deriving (ToAttribute) via ToAttributeShow BlockHash
 
 
 blockHashFromHeader :: CardanoHeader -> BlockHash

--- a/src/Hoard/Data/ID.hs
+++ b/src/Hoard/Data/ID.hs
@@ -7,9 +7,12 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.UUID (UUID)
 import Rel8 (DBEq, DBOrd, DBType)
 
+import Hoard.Effects.Monitoring.Tracing (ToAttribute, ToAttributeShow (..))
+
 
 -- | Phantom type around a UUID, to distinguish between different types of identifiers.
 -- E.g. @ID Peer@ vs @ID Block@.
 newtype ID a = ID UUID
     deriving stock (Generic)
     deriving newtype (DBEq, DBOrd, DBType, Eq, FromJSON, Hashable, Ord, Show, ToJSON)
+    deriving (ToAttribute) via (ToAttributeShow (ID a))

--- a/src/Hoard/Data/Peer.hs
+++ b/src/Hoard/Data/Peer.hs
@@ -15,6 +15,7 @@ import Data.IP qualified as IP
 import Text.Show qualified as Show
 
 import Hoard.Data.ID (ID)
+import Hoard.Effects.Monitoring.Tracing (ToAttribute, ToAttributeShow (..))
 import Hoard.Types.NodeIP (NodeIP (..))
 
 
@@ -39,6 +40,7 @@ data PeerAddress = PeerAddress
     }
     deriving (FromJSON, ToJSON)
     deriving stock (Eq, Generic, Ord)
+    deriving (ToAttribute) via (ToAttributeShow PeerAddress)
 
 
 instance Show PeerAddress where

--- a/src/Hoard/Effects/DBRead.hs
+++ b/src/Hoard/Effects/DBRead.hs
@@ -41,7 +41,7 @@ runDBRead eff = do
     pool <- asks $ DB.readerPool
     interpretWith_ eff \case
         RunQuery queryName stmt -> withSpan "db.query" $ do
-            addAttribute "db.operation" "read"
+            addAttribute @Text "db.operation" "read"
             addAttribute "db.query.name" queryName
             counterInc metricDBQueries
             withHistogramTiming metricDBQueryDuration $ do

--- a/src/Hoard/Effects/DBWrite.hs
+++ b/src/Hoard/Effects/DBWrite.hs
@@ -39,9 +39,9 @@ runDBWrite eff = do
     pool <- asks $ DB.writerPool
     interpretWith_ eff \case
         RunTransaction txName tx -> withSpan "db.transaction" $ do
-            addAttribute "db.operation" "write"
+            addAttribute @Text "db.operation" "write"
             addAttribute "db.transaction.name" txName
-            addAttribute "db.isolation_level" "ReadCommitted"
+            addAttribute @Text "db.isolation_level" "ReadCommitted"
 
             result <- liftIO $ Pool.use pool (transaction ReadCommitted Write tx)
             case result of

--- a/src/Hoard/Effects/NodeToNode/ChainSync.hs
+++ b/src/Hoard/Effects/NodeToNode/ChainSync.hs
@@ -108,8 +108,8 @@ client unlift peer =
             -- Publish started event
             timestamp <- Clock.currentTime
             publish $ ChainSyncStarted {peer, timestamp}
-            addEvent "protocol_started" []
-            addEvent "finding_intersection" []
+            addEvent @Int "protocol_started" []
+            addEvent @Int "finding_intersection" []
             initialPoints <-
                 fmap List.singleton
                     . fmap toConsensusPointHF
@@ -122,10 +122,10 @@ client unlift peer =
     findIntersect initialPoints =
         Yield (ChainSync.MsgFindIntersect initialPoints) $ Await $ \case
             ChainSync.MsgIntersectNotFound {} -> Effect $ unlift $ do
-                addEvent "intersection_not_found" []
+                addEvent @Int "intersection_not_found" []
                 pure requestNext
             ChainSync.MsgIntersectFound point tip -> Effect $ unlift $ do
-                addEvent "intersection_found" [("point", show point), ("tip", show tip)]
+                addEvent @Text "intersection_found" [("point", show point), ("tip", show tip)]
                 timestamp <- Clock.currentTime
                 publish
                     $ ChainSyncIntersectionFound
@@ -153,7 +153,7 @@ client unlift peer =
                 pure requestNext
             ChainSync.MsgRollBackward point tip -> Effect $ unlift $ do
                 recordChainSyncRollback
-                addEvent "rollback" [("point", show point), ("tip", show tip)]
+                addEvent @Text "rollback" [("point", show point), ("tip", show tip)]
                 timestamp <- Clock.currentTime
                 publish
                     $ RollBackward
@@ -177,7 +177,7 @@ client unlift peer =
                     pure requestNext
                 ChainSync.MsgRollBackward point tip -> Effect $ unlift $ do
                     recordChainSyncRollback
-                    addEvent "rollback_after_await" [("point", show point), ("tip", show tip)]
+                    addEvent @Text "rollback_after_await" [("point", show point), ("tip", show tip)]
                     timestamp <- Clock.currentTime
                     publish
                         $ RollBackward

--- a/src/Hoard/Effects/NodeToNode/KeepAlive.hs
+++ b/src/Hoard/Effects/NodeToNode/KeepAlive.hs
@@ -57,7 +57,7 @@ miniProtocol conf unlift codecs peer =
                             $ withExceptionLogging "KeepAlive"
                             $ withSpan "keep_alive_protocol"
                             $ do
-                                addEvent "protocol_started" []
+                                addEvent @Int "protocol_started" []
                                 pure (keepAliveClientPeer $ client unlift conf peer)
                         tracer = show >$< asTracer unlift "keep_alive.protocol_message"
                     in  (tracer, codec, wrappedPeer)
@@ -82,13 +82,13 @@ client
 client unlift conf peer = KeepAliveClient sendFirst
   where
     sendFirst = unlift do
-        addEvent "sending_first_keepalive" []
+        addEvent @Int "sending_first_keepalive" []
         timestamp <- Clock.currentTime
         publish KeepAlivePing {timestamp, peer}
         pure $ SendMsgKeepAlive (Cookie 42) sendNext
 
     sendNext = unlift do
-        addEvent "keepalive_response_received" [("wait_seconds", show (conf.intervalMicroseconds `div` 1_000_000))]
+        addEvent "keepalive_response_received" [("wait_seconds", conf.intervalMicroseconds `div` 1_000_000)]
         threadDelay conf.intervalMicroseconds
-        addEvent "sending_keepalive" []
+        addEvent @Int "sending_keepalive" []
         pure $ SendMsgKeepAlive (Cookie 42) sendNext

--- a/src/Hoard/Effects/NodeToNode/PeerSharing.hs
+++ b/src/Hoard/Effects/NodeToNode/PeerSharing.hs
@@ -60,7 +60,7 @@ miniProtocol conf unlift' codecs peer =
                         wrappedPeer = Peer.Effect $ unlift $ withExceptionLogging "PeerSharing" $ withSpan "peer_sharing_protocol" $ do
                             timestamp <- Clock.currentTime
                             publish $ PeerSharingStarted {peer, timestamp}
-                            addEvent "protocol_started" []
+                            addEvent @Int "protocol_started" []
                             pure (peerSharingClientPeer peerSharingClient)
                         tracer = show >$< asTracer unlift "peer_sharing.protocol_message"
                     in  (tracer, codec, wrappedPeer)
@@ -87,7 +87,7 @@ client unlift conf peer = requestPeers withPeers
   where
     requestPeers = SendMsgShareRequest $ PeerSharingAmount $ fromIntegral conf.requestAmount
     withPeers peerAddrs = unlift do
-        addEvent "peer_sharing_response_received" [("peer_count", show $ length peerAddrs)]
+        addEvent "peer_sharing_response_received" [("peer_count", length peerAddrs)]
         timestamp <- Clock.currentTime
         publish
             $ PeersReceived
@@ -95,7 +95,7 @@ client unlift conf peer = requestPeers withPeers
                 , timestamp
                 , peerAddresses = S.fromList $ mapMaybe sockAddrToPeerAddress peerAddrs
                 }
-        addEvent "waiting_for_next_request" [("wait_seconds", show (conf.requestIntervalMicroseconds `div` 1_000_000))]
+        addEvent "waiting_for_next_request" [("wait_seconds", conf.requestIntervalMicroseconds `div` 1_000_000)]
         threadDelay conf.requestIntervalMicroseconds
-        addEvent "sending_next_request" []
+        addEvent @Int "sending_next_request" []
         pure $ requestPeers withPeers

--- a/src/Hoard/OrphanDetection/Data.hs
+++ b/src/Hoard/OrphanDetection/Data.hs
@@ -6,6 +6,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Rel8 (DBEq, DBType, ReadShow (..))
 import Servant (FromHttpApiData (..), ToHttpApiData (..))
 
+import Hoard.Effects.Monitoring.Tracing (ToAttribute, ToAttributeShow (..))
 import Hoard.Types.JsonReadShow (JsonReadShow (..))
 
 
@@ -18,6 +19,7 @@ data BlockClassification
     deriving (Eq, Read, Show)
     deriving (FromJSON, ToJSON) via (JsonReadShow BlockClassification)
     deriving (DBEq, DBType) via (ReadShow BlockClassification)
+    deriving (ToAttribute) via (ToAttributeShow BlockClassification)
 
 
 -- | HTTP API instances for Servant

--- a/test/Unit/Hoard/Effects/QuotaSpec.hs
+++ b/test/Unit/Hoard/Effects/QuotaSpec.hs
@@ -194,5 +194,5 @@ checkStatus = withQuotaCheck @Int 1 $ \_ status -> pure status
 
 
 -- | Check the quota for a specific key and return the status
-checkStatusForKey :: (Hashable key, Ord key, Quota key :> es, Show key) => key -> Eff es MessageStatus
+checkStatusForKey :: (Hashable key, Ord key, Quota key :> es) => key -> Eff es MessageStatus
 checkStatusForKey key = withQuotaCheck key $ \_ status -> pure status


### PR DESCRIPTION
Depends on #270 and #271

This PR attempts to keep events and attributes as they are with some exceptions:
- Values that have a `ToAttribute` instance but where `show`ed with the previous implementation are now passed as-is instead.
- Some values which we expect to add to traces often have their own `ToAttribute` added. Examples include `ID a` and `BlockHash`.