### PR TITLE
fix: handle unknown connection errors gracefully

### DIFF
--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -20,12 +20,12 @@ import Data.Traversable (for)
 import Effectful (Eff, Effect, IOE, Limit (..), Persistence (..), UnliftStrategy (..), withEffToIO, (:>))
 import Effectful.Concurrent (Concurrent)
 import Effectful.Dispatch.Dynamic (interpret_)
-import Effectful.Exception (Handler (..), IOException, catches, throwIO)
+import Effectful.Exception (Handler (..), IOException, catches)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State)
 import Effectful.TH (makeEffect)
 import Effectful.Timeout (Timeout)
-import GHC.IO.Exception (IOErrorType (..), IOException (..), ioError, userError)
+import GHC.IO.Exception (IOErrorType (..), IOException (..), ioError)
 import Network.Mux (Mode (..))
 import Network.Socket (SockAddr, Socket)
 import Ouroboros.Consensus.Config (TopLevelConfig (..))
@@ -255,7 +255,7 @@ runNodeToNode =
             _ -> do
                 addEvent "io_exception" [("type", "Unknown"), ("error", show e)]
                 setStatus $ Error errMsg
-                throwIO $ userError $ toString errMsg
+                pure $ ConnectToError errMsg
 
     handleMuxError :: Peer -> Mux.Error -> Eff es ConnectToError
     handleMuxError peer = \case
@@ -270,7 +270,7 @@ runNodeToNode =
             let errMsg = "Disconnected due to unknown ouroboros error: " <> show e
             addEvent "mux_error" [("type", "Unknown"), ("error", show e)]
             setStatus $ Error errMsg
-            throwIO $ userError $ toString errMsg
+            pure $ ConnectToError errMsg
 
     handleHandshakeProtocolError :: Peer -> HandshakeProtocolError NodeToNodeVersion -> Eff es ConnectToError
     handleHandshakeProtocolError peer e = do


### PR DESCRIPTION
I've witnessed the app crash due to one of these errors.

Previously, unknown `IOException` types (e.g., permission denied) and unknown `Mux` errors were re-thrown from exception handlers, causing the application to crash. This happened because re-throwing from inside a handler causes the exception to escape the catches block.

Now these errors return `ConnectToError` like other connection failures, allowing the peer connection to fail gracefully while the app continues running and connecting to other peers.