### PR TITLE
feat: auto span linking for pub-sub and cross-thread tracing with parent-child relationship

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -68,7 +68,6 @@ main =
         . runConcurrent
         . runTimeout
         . runChan
-        . runConc
         . loadOptions
         . runConfigPath
         . loadEnv
@@ -99,6 +98,7 @@ main =
         . evalState @HoardState def
         . evalState @Peers def
         . Sentry.runDuplicateBlocksState
+        . runConc
         . runQuota @PeerSlotKey 1
         . runPubSub @ChainSyncStarted
         . runPubSub @ChainSyncIntersectionFound

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -88,11 +88,11 @@ runEffectStackTest eff = liftIO $ do
         runEff
             . runFileSystem
             . runChan
+            . runTracingNoOp
             . runConc
             . runReader (def :: Log.Config)
             . runLog
             . runClockConst testTime
-            . runTracingNoOp
             . runMetrics
             . runState @[Block] []
             . runBlockRepoState
@@ -106,11 +106,11 @@ type TestAppEffs =
     , BlockRepo
     , State [Block]
     , Metrics
-    , Tracing
     , Clock
     , Log
     , Reader Log.Config
     , Conc
+    , Tracing
     , Chan
     , FileSystem
     , IOE

--- a/test/Unit/Hoard/Effects/ConcSpec.hs
+++ b/test/Unit/Hoard/Effects/ConcSpec.hs
@@ -8,6 +8,7 @@ import Prelude
 import Data.IORef qualified as IORef
 
 import Hoard.Effects.Conc (Conc, fork_, runConc, scoped)
+import Hoard.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
 
 
 spec_Conc :: Spec
@@ -81,5 +82,5 @@ spec_Conc = do
 -- Test Helpers
 --------------------------------------------------------------------------------
 
-runTest :: Eff '[Conc, Concurrent, IOE] a -> IO a
-runTest = runEff . runConcurrent . runConc
+runTest :: Eff '[Conc, Tracing, Concurrent, IOE] a -> IO a
+runTest = runEff . runConcurrent . runTracingNoOp . runConc


### PR DESCRIPTION
Automatically captures span context when publishing events and creates linked spans in listeners, enabling distributed tracing of async event flows.

Add new withSpanAsChild primitive to Tracing effect that allows creating child spans with explicit parent context, reserving
trace hierarchy across thread boundaries.

Switch main effect stack to use `runConcTracedNewScope` for traced concurrency support.