### PR TITLE
refactor: clean up stray events, prefer spans and remove unnecessary attributes

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -86,6 +86,7 @@ main =
         . runConfig @"tracing" @TracingConfig
         . runConfig @"sentry" @Sentry.Config
         . runLog
+        . runTracingFromConfig
         . runClock
         . runFileSystem
         . runTemporary
@@ -98,7 +99,6 @@ main =
         . evalState @HoardState def
         . evalState @Peers def
         . Sentry.runDuplicateBlocksState
-        . runTracingFromConfig
         . runQuota @PeerSlotKey 1
         . runPubSub @ChainSyncStarted
         . runPubSub @ChainSyncIntersectionFound

--- a/src/Hoard/BlockEviction.hs
+++ b/src/Hoard/BlockEviction.hs
@@ -28,7 +28,7 @@ component =
             cfg <- ask
             let interval = cfg.evictionIntervalSeconds
             pure
-                [ every interval $ withSpan "block_eviction.evict" $ do
+                [ every interval $ withSpan "block_eviction.evict" do
                     count <- BlockRepo.evictBlocks
                     addAttribute "evicted.count" count
                 ]

--- a/src/Hoard/Effects/NodeToClient.hs
+++ b/src/Hoard/Effects/NodeToClient.hs
@@ -109,12 +109,12 @@ runNodeToClient nodeToClient = do
         interpretWith_
             (inject nodeToClient)
             ( \case
-                ImmutableTip -> withSpan "node_query.immutable_tip" $ do
+                ImmutableTip -> withSpan "node_to_client.immutable_tip" do
                     Connection immutableTipQueries _ dead <- ensureConnection
                     resultVar <- newEmptyMVar
                     liftIO $ writeChan immutableTipQueries resultVar
                     rightToMaybe <$> race (readMVar dead) (readMVar resultVar)
-                IsOnChain point -> withSpan "node_query.is_on_chain" $ do
+                IsOnChain point -> withSpan "node_to_client.is_on_chain" do
                     Connection _ isOnChainQueries dead <- ensureConnection
                     resultVar <- newEmptyMVar
                     liftIO $ writeChan isOnChainQueries (point, resultVar)
@@ -122,18 +122,37 @@ runNodeToClient nodeToClient = do
             )
 
 
-newConnection :: (Concurrent :> es, IOE :> es) => Eff es (Connection, (OutChan (MVar ChainPoint), OutChan (ChainPoint, MVar Bool), MVar SomeException))
-newConnection =
-    do
-        (immutableTipQueriesIn, immutableTipQueriesOut) <- liftIO newChan
-        (isOnChainQueriesIn, isOnChainQueriesOut) <- liftIO newChan
-        dead <- newEmptyMVar
-        pure (Connection immutableTipQueriesIn isOnChainQueriesIn dead, (immutableTipQueriesOut, isOnChainQueriesOut, dead))
+newConnection
+    :: (Concurrent :> es, IOE :> es)
+    => Eff
+        es
+        ( Connection
+        , ( OutChan (MVar ChainPoint)
+          , OutChan (ChainPoint, MVar Bool)
+          , MVar SomeException
+          )
+        )
+newConnection = do
+    (immutableTipQueriesIn, immutableTipQueriesOut) <- liftIO newChan
+    (isOnChainQueriesIn, isOnChainQueriesOut) <- liftIO newChan
+    dead <- newEmptyMVar
+    pure (Connection immutableTipQueriesIn isOnChainQueriesIn dead, (immutableTipQueriesOut, isOnChainQueriesOut, dead))
 
 
-initializeConnection :: (Conc :> es, Concurrent :> es, IOE :> es, Labeled "nodeToClient" WithSocket :> es, Log :> es, Reader (ProtocolInfo CardanoBlock) :> es, Reader NodeConfig :> es, State (Either SomeException Connection) :> es) => (OutChan (MVar ChainPoint), OutChan (ChainPoint, MVar Bool), MVar SomeException) -> Eff es (Thread ())
+initializeConnection
+    :: ( Conc :> es
+       , Concurrent :> es
+       , IOE :> es
+       , Labeled "nodeToClient" WithSocket :> es
+       , Log :> es
+       , Reader (ProtocolInfo CardanoBlock) :> es
+       , Reader NodeConfig :> es
+       , State (Either SomeException Connection) :> es
+       , Tracing :> es
+       )
+    => (OutChan (MVar ChainPoint), OutChan (ChainPoint, MVar Bool), MVar SomeException) -> Eff es (Thread ())
 initializeConnection =
-    ( \(immutableTipQueriesOut, isOnChainQueriesOut, dead) -> do
+    ( \(immutableTipQueriesOut, isOnChainQueriesOut, dead) -> withSpan "node_to_client.initialize_connection" do
         protocolInfo <- ask @(ProtocolInfo CardanoBlock)
         nodeConfig <- ask @NodeConfig
         epochSize <- loadEpochSize nodeConfig
@@ -169,9 +188,10 @@ ensureConnection
        , Reader (ProtocolInfo CardanoBlock) :> es
        , Reader NodeConfig :> es
        , State (Either SomeException Connection) :> es
+       , Tracing :> es
        )
     => Eff es Connection
-ensureConnection = do
+ensureConnection = withSpan "node_to_client.ensure_connection" do
     (connection, newConnectionHandlesMaybe) <-
         stateM
             ( \case

--- a/src/Hoard/Listeners.hs
+++ b/src/Hoard/Listeners.hs
@@ -6,6 +6,7 @@ import Prelude hiding (Reader, State)
 
 import Hoard.Effects.Conc (Conc)
 import Hoard.Effects.HoardStateRepo (HoardStateRepo)
+import Hoard.Effects.Log (Log)
 import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Pub, Sub, listen)
@@ -21,6 +22,7 @@ import Hoard.Effects.Conc qualified as Conc
 runListeners
     :: ( Conc :> es
        , HoardStateRepo :> es
+       , Log :> es
        , NodeToClient :> es
        , Pub ImmutableTipRefreshed :> es
        , State HoardState :> es

--- a/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
+++ b/src/Hoard/Listeners/ImmutableTipRefreshTriggeredListener.hs
@@ -9,7 +9,7 @@ import Effectful.State.Static.Shared (State, gets, modifyM)
 import Prelude hiding (State, gets, modify)
 
 import Hoard.Effects.HoardStateRepo (HoardStateRepo, persistImmutableTip)
-import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, addEvent, withSpan)
+import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, setStatus, withSpan)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Pub, publish)
 import Hoard.Events.ImmutableTipRefreshTriggered
@@ -25,14 +25,19 @@ import Hoard.Effects.NodeToClient qualified as NodeToClient
 -- This is called regularly and during application setup to initialize the immutable tip
 -- before we start connecting to peers.
 -- If fetching the tip fails due to a connection error, it retries once to reconnect and fetch.
-immutableTipRefreshTriggeredListener :: (NodeToClient :> es, Pub ImmutableTipRefreshed :> es, State HoardState :> es, Tracing :> es) => ImmutableTipRefreshTriggered -> Eff es ()
-immutableTipRefreshTriggeredListener ImmutableTipRefreshTriggered = withSpan "immutable_tip.refresh" $ do
-    addEvent @Int "fetching_immutable_tip" []
+immutableTipRefreshTriggeredListener
+    :: ( NodeToClient :> es
+       , Pub ImmutableTipRefreshed :> es
+       , State HoardState :> es
+       , Tracing :> es
+       )
+    => ImmutableTipRefreshTriggered -> Eff es ()
+immutableTipRefreshTriggeredListener ImmutableTipRefreshTriggered = withSpan "immutable_tip.refresh" do
     NodeToClient.immutableTip >>= \case
-        Nothing -> addEvent @Text "fetch_failed" [("reason", "connection may be down")]
+        Nothing ->
+            setStatus $ Error "Fetch failed: connection may be down"
         Just tip -> do
-            addAttribute "immutable_tip" $ show @Text tip
-            addEvent "immutable_tip_updated" [("tip", show @Text tip)]
+            setStatus Ok
             modifyM $ \hoardState ->
                 if hoardState.immutableTip < tip then
                     publish ImmutableTipRefreshed $> hoardState {immutableTip = tip}
@@ -44,9 +49,12 @@ data ImmutableTipRefreshed = ImmutableTipRefreshed
 
 
 -- | Persist the updated immutable tip to the database.
-immutableTipRefreshedListener :: (HoardStateRepo :> es, State HoardState :> es, Tracing :> es) => ImmutableTipRefreshed -> Eff es ()
-immutableTipRefreshedListener ImmutableTipRefreshed = withSpan "immutable_tip.persist" $ do
+immutableTipRefreshedListener
+    :: ( HoardStateRepo :> es
+       , State HoardState :> es
+       , Tracing :> es
+       )
+    => ImmutableTipRefreshed -> Eff es ()
+immutableTipRefreshedListener ImmutableTipRefreshed = withSpan "immutable_tip.persist" do
     tip <- gets (.immutableTip)
-    addAttribute "immutable_tip" $ show @Text tip
-    addEvent "persisting_immutable_tip" [("tip", show @Text tip)]
     persistImmutableTip tip

--- a/src/Hoard/Listeners/NetworkEventListener.hs
+++ b/src/Hoard/Listeners/NetworkEventListener.hs
@@ -2,16 +2,16 @@ module Hoard.Listeners.NetworkEventListener (protocolErrorListener) where
 
 import Effectful (Eff, (:>))
 
-import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent)
-import Hoard.Events.Network
-    ( ProtocolError (..)
-    )
+import Hoard.Effects.Log (Log)
+import Hoard.Events.Network (ProtocolError (..))
+
+import Hoard.Effects.Log qualified as Log
 
 
 -- | Listener that logs protocol error events
 protocolErrorListener
-    :: (Tracing :> es)
+    :: (Log :> es)
     => ProtocolError
     -> Eff es ()
-protocolErrorListener event = do
-    addEvent "protocol_error_event" [("error", event.errorMessage)]
+protocolErrorListener event =
+    Log.err $ "Protocol error: " <> event.errorMessage

--- a/src/Hoard/Monitoring.hs
+++ b/src/Hoard/Monitoring.hs
@@ -17,13 +17,15 @@ import Prelude hiding (Reader, State, asks, gets)
 
 import Cardano.Api qualified as C
 import Data.Set qualified as S
+import Data.Text qualified as T
 
 import Hoard.Component (Component (..), defaultComponent)
 import Hoard.DB.Schema (countRows, countRowsWhere)
 import Hoard.Effects.DBRead (DBRead)
-import Hoard.Effects.Log (Log, withNamespace)
+import Hoard.Effects.Log (Log)
 import Hoard.Effects.Monitoring.Metrics (Metrics, gaugeSet)
 import Hoard.Effects.Monitoring.Metrics.Definitions (metricBlocksBeingClassified, metricBlocksInDB, metricConnectedPeers, metricUnclassifiedBlocks)
+import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
 import Hoard.Effects.Publishing (Pub, Sub, publish)
 import Hoard.PeerManager.Peers (Connection (..), ConnectionState (..), Peers (..))
 import Hoard.Triggers (every)
@@ -46,6 +48,7 @@ component
        , State HoardState :> es
        , State Peers :> es
        , Sub Poll :> es
+       , Tracing :> es
        )
     => Component es
 component =
@@ -64,28 +67,38 @@ listener
        , Metrics :> es
        , State HoardState :> es
        , State Peers :> es
+       , Tracing :> es
        )
     => Poll
     -> Eff es ()
-listener Poll = do
-    withNamespace "Monitoring" $ do
-        peers <- gets @Peers $ toList . (.peers)
-        let (connectedPeers, pendingPeers) = bimap length length $ partition ((== Connected) . (.state)) peers
-        tip <- gets @HoardState (.immutableTip)
-        blockCount <- countRows BlocksSchema.schema
-        unclassifiedCount <- countRowsWhere BlocksSchema.schema (\row -> isNull row.classification)
-        beingClassifiedCount <- gets @HoardState (S.size . (.blocksBeingClassified))
+listener Poll = withSpan "monitoring" do
+    peers <- gets @Peers $ toList . (.peers)
+    let (connectedPeers, pendingPeers) = bimap length length $ partition ((== Connected) . (.state)) peers
+    tip <- gets @HoardState (.immutableTip)
+    blockCount <- countRows BlocksSchema.schema
+    unclassifiedCount <- countRowsWhere BlocksSchema.schema (\row -> isNull row.classification)
+    beingClassifiedCount <- gets @HoardState (S.size . (.blocksBeingClassified))
 
-        -- Update metrics
-        gaugeSet metricConnectedPeers (fromIntegral connectedPeers)
-        gaugeSet metricBlocksInDB (fromIntegral blockCount)
-        gaugeSet metricUnclassifiedBlocks (fromIntegral unclassifiedCount)
-        gaugeSet metricBlocksBeingClassified (fromIntegral beingClassifiedCount)
+    -- Update metrics
+    gaugeSet metricConnectedPeers (fromIntegral connectedPeers)
+    gaugeSet metricBlocksInDB (fromIntegral blockCount)
+    gaugeSet metricUnclassifiedBlocks (fromIntegral unclassifiedCount)
+    gaugeSet metricBlocksBeingClassified (fromIntegral beingClassifiedCount)
 
-        let tipSlot = case coerce tip of
-                C.ChainPointAtGenesis -> "genesis"
-                C.ChainPoint slot _ -> show slot
-        Log.info $ "Currently connected to " <> show connectedPeers <> " peers | " <> show pendingPeers <> " peer connections pending | Immutable tip slot: " <> tipSlot <> " | Blocks in DB: " <> show blockCount <> " | Unclassified: " <> show unclassifiedCount <> " | Being classified: " <> show beingClassifiedCount
+    let tipSlot = case coerce tip of
+            C.ChainPointAtGenesis -> "genesis"
+            C.ChainPoint slot _ -> show slot
+    Log.withNamespace "Monitoring"
+        $ Log.info
+        $ T.intercalate
+            " | "
+            [ "Current peer connections: " <> show connectedPeers
+            , "Pending peer connections: " <> show pendingPeers
+            , "Immutable tip slot: " <> tipSlot
+            , "Blocks in DB: " <> show blockCount
+            , "Unclassified blocks: " <> show unclassifiedCount
+            , "Blocks being classified: " <> show beingClassifiedCount
+            ]
 
 
 data Poll = Poll

--- a/src/Hoard/OrphanDetection.hs
+++ b/src/Hoard/OrphanDetection.hs
@@ -8,13 +8,15 @@ import Prelude hiding (State)
 import Hoard.Component (Component (..), defaultComponent)
 import Hoard.Effects.BlockRepo (BlockRepo)
 import Hoard.Effects.Clock (Clock)
-import Hoard.Effects.Monitoring.Tracing (Tracing, addEvent, withSpan)
+import Hoard.Effects.Log (Log)
+import Hoard.Effects.Monitoring.Tracing (Tracing)
 import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Sub)
 import Hoard.Events.BlockFetch (BlockReceived)
 import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed)
 import Hoard.Types.HoardState (HoardState)
 
+import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.Publishing qualified as Sub
 import Hoard.OrphanDetection.Listeners qualified as Listeners
 
@@ -22,6 +24,7 @@ import Hoard.OrphanDetection.Listeners qualified as Listeners
 component
     :: ( BlockRepo :> es
        , Clock :> es
+       , Log :> es
        , NodeToClient :> es
        , State HoardState :> es
        , Sub BlockReceived :> es
@@ -34,14 +37,14 @@ component =
         { name = "OrphanDetection"
         , listeners =
             let
-                withErrorHandling listenerName listener event =
-                    withSpan listenerName
+                withErrorHandling listener event =
+                    Log.withNamespace "OrphanDetection"
                         $ runErrorNoCallStack (listener event) >>= \case
-                            Left err -> addEvent "listener_error" [("error", err)]
+                            Left err -> Log.err $ "Listener failed with error " <> err
                             Right () -> pure ()
             in
                 pure
-                    [ Sub.listen $ withErrorHandling "block_received_classifier" Listeners.blockReceivedClassifier
-                    , Sub.listen $ withErrorHandling "immutable_tip_ager" Listeners.immutableTipUpdatedAger
+                    [ Sub.listen $ withErrorHandling Listeners.blockReceivedClassifier
+                    , Sub.listen $ withErrorHandling Listeners.immutableTipUpdatedAger
                     ]
         }

--- a/src/Hoard/Sentry.hs
+++ b/src/Hoard/Sentry.hs
@@ -86,7 +86,6 @@ duplicateBlockGuard
        )
     => BlockReceived -> Eff es ()
 duplicateBlockGuard event = withSpan "sentry.duplicate_block_guard" do
-    addAttribute "peer.id" event.peer.id
     addAttribute "peer.address" event.peer.address
     addAttribute "request.id" $ show @Text event.requestId
     let blockHash = blockHashFromHeader $ getHeader event.block

--- a/test/Hoard/TestHelpers.hs
+++ b/test/Hoard/TestHelpers.hs
@@ -39,6 +39,7 @@ import Hoard.Effects.Clock (Clock, runClockConst)
 import Hoard.Effects.Conc (Conc, runConc)
 import Hoard.Effects.Log (Log, runLog)
 import Hoard.Effects.Monitoring.Metrics (Metrics, runMetrics)
+import Hoard.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
 import Hoard.Types.HoardState (HoardState)
 
 import Hoard.Effects.Log qualified as Log
@@ -91,6 +92,7 @@ runEffectStackTest eff = liftIO $ do
             . runReader (def :: Log.Config)
             . runLog
             . runClockConst testTime
+            . runTracingNoOp
             . runMetrics
             . runState @[Block] []
             . runBlockRepoState
@@ -104,6 +106,7 @@ type TestAppEffs =
     , BlockRepo
     , State [Block]
     , Metrics
+    , Tracing
     , Clock
     , Log
     , Reader Log.Config

--- a/test/Unit/Hoard/CollectorSpec.hs
+++ b/test/Unit/Hoard/CollectorSpec.hs
@@ -15,7 +15,7 @@ import Prelude hiding (evalState, execState)
 
 import Data.UUID qualified as UUID
 
-import Hoard.Collector (pickBlockFetchRequest)
+import Hoard.Collector (filterHeaderReceived)
 import Hoard.Data.Block (Block (..))
 import Hoard.Data.BlockHash (blockHashFromHeader)
 import Hoard.Data.ID (ID (..))
@@ -84,7 +84,7 @@ testPeer =
 
 spec_Collector :: Spec
 spec_Collector = do
-    describe "pickBlockFetchRequest" do
+    describe "filterHeaderReceived" do
         it "should not issue request for existing block" do
             let reqs = runEff [dbBlock]
             reqs `shouldBe` []
@@ -110,5 +110,5 @@ spec_Collector = do
                     . evalState db
                     . runBlockRepoState
                     . runAllValidVerifier
-                    $ pickBlockFetchRequest testPeer.id headerReceived
+                    $ filterHeaderReceived testPeer.id headerReceived
         in  events

--- a/test/Unit/Hoard/Effects/QuotaSpec.hs
+++ b/test/Unit/Hoard/Effects/QuotaSpec.hs
@@ -11,6 +11,7 @@ import Data.IORef qualified as IORef
 
 import Hoard.Effects.Clock (Clock, runClock)
 import Hoard.Effects.Conc (Conc, runConc)
+import Hoard.Effects.Log (Log, runLogNoOp)
 import Hoard.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
 import Hoard.Effects.Quota (Config (..), MessageStatus (..), Quota, runQuota, withQuotaCheck)
 
@@ -171,10 +172,11 @@ spec_Quota = do
 --------------------------------------------------------------------------------
 
 -- | Run a quota test with the given max messages
-runQuotaTest :: Int -> Eff '[Quota Int, Reader Config, Clock, Conc, Tracing, Concurrent, IOE] a -> IO a
+runQuotaTest :: Int -> Eff '[Quota Int, Reader Config, Clock, Conc, Tracing, Log, Concurrent, IOE] a -> IO a
 runQuotaTest maxMessages action =
     runEff
         . runConcurrent
+        . runLogNoOp
         . runTracingNoOp
         . runConc
         . runClock

--- a/test/Unit/Hoard/MonitoringSpec.hs
+++ b/test/Unit/Hoard/MonitoringSpec.hs
@@ -51,7 +51,7 @@ spec_Monitoring = withCleanTestDatabase $ do
                             }
                     . evalState peers
                     $ Monitoring.listener Monitoring.Poll
-            logs `shouldBe` [(INFO, "Currently connected to 1 peers | 2 peer connections pending | Immutable tip slot: genesis | Blocks in DB: 0 | Unclassified: 0 | Being classified: 0")]
+            logs `shouldBe` [(INFO, "Current peer connections: 1 | Pending peer connections: 2 | Immutable tip slot: genesis | Blocks in DB: 0 | Unclassified blocks: 0 | Blocks being classified: 0")]
 
 
 mkPeers :: (Concurrent :> es) => UTCTime -> Int -> Eff es Peers


### PR DESCRIPTION
Depends on #273

This PR attempts to do the following:
- Remove stray `addEvent`s that do not have a clear corresponding `withSpan` that they will attach to. These `addEvent` calls would either attach to whatever currently running span is relevant for the thread, or they would be a no-op. Either way, which span they attached to was unintuitive in cases where it was not explicit which span they would attach to, so I removed those that I deemed redundant, or adapted those that seemed to be of value.
- Prefer spans instead of "start" and "end" events. This is literally the major use-case for spans. Spans always have a start and end.
- Remove unnecessary attributes. Attributes that do not have a clear impact on the runtime or computation of the code enclosed in the relevant span will not be added to the span. If necessary, they can be readded on a case-by-case basis.
- Use log statements instead of spans for long-running tasks and functions. Spans are only sent to Tempo once they complete. Long-running spans for services that are not expected to stop will never end up in Tempo/Grafana. Use log statements to emit "events" about them starting instead.