### PR TITLE
feat: add Loki for log aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ prometheus-data/
 tempo-data/
 node-db/
 .env.local
+loki-data/
+log.out
+promtail-data/

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -91,6 +91,9 @@ monitoring:
     http_port: 3200
     block_retention: "24h"
     max_block_duration: "5m"
+  loki:
+    http_port: 3100
+    retention_period: "24h"
   node_exporter:
     port: 9100
 


### PR DESCRIPTION
- Add Loki for log aggregation from `stdout`.
- Add `promtail` to ship logs from a log file into Loki.
- Log output written to `./log.out` is automatically pushed to Loki by `promtail`.