### PR TITLE
fix: prevent thread leak in collector by scoping thread lifetime

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -317,6 +317,7 @@ test-suite hoard-test
       Unit.Hoard.Data.BlockSpec
       Unit.Hoard.Data.PeerSpec
       Unit.Hoard.Effects.Cache.SingleflightSpec
+      Unit.Hoard.Effects.ConcSpec
       Unit.Hoard.Effects.LogSpec
       Unit.Hoard.Effects.PublishingSpec
       Unit.Hoard.Effects.QuotaSpec

--- a/test/Unit/Hoard/Effects/ConcSpec.hs
+++ b/test/Unit/Hoard/Effects/ConcSpec.hs
@@ -1,0 +1,85 @@
+module Unit.Hoard.Effects.ConcSpec (spec_Conc) where
+
+import Effectful (Eff, IOE, runEff)
+import Effectful.Concurrent (Concurrent, runConcurrent, threadDelay)
+import Test.Hspec (Spec, context, describe, it, shouldBe, shouldSatisfy)
+import Prelude
+
+import Data.IORef qualified as IORef
+
+import Hoard.Effects.Conc (Conc, fork_, runConc, scoped)
+
+
+spec_Conc :: Spec
+spec_Conc = do
+    describe "Thread cleanup" do
+        context "without scoped" do
+            it "demonstrates thread leak" do
+                -- This test shows we CANNOT currently create a nested scope that cleans up
+                -- When we try to simulate a connection lifecycle, threads leak
+                result <- runTest $ do
+                    counter <- liftIO $ IORef.newIORef (0 :: Int)
+
+                    -- Simulate connection lifecycle - we want this to be a scope that exits
+                    -- But we have no way to create a nested Ki scope currently!
+                    -- So the thread we fork here will live until the root scope exits
+                    let simulateConnection = do
+                            fork_ $ forever $ do
+                                liftIO $ IORef.atomicModifyIORef' counter (\n -> (n + 1, ()))
+                                threadDelay 10000 -- 10ms
+                                -- Let it run a bit
+                            threadDelay 25000 -- 25ms
+                            -- "Connection" ends here, but thread continues...
+                    simulateConnection
+
+                    -- Capture count after "connection" ended
+                    countAfter <- liftIO $ IORef.readIORef counter
+
+                    -- Wait to see if thread keeps running (it will - that's the bug)
+                    threadDelay 50000 -- 50ms
+
+                    -- Count increased even after connection scope "ended"
+                    finalCount <- liftIO $ IORef.readIORef counter
+
+                    pure (countAfter, finalCount)
+
+                let (countAfter, finalCount) = result
+                -- finalCount should be GREATER than countAfter (thread leaked)
+                finalCount `shouldSatisfy` (> countAfter)
+
+        context "with scoped" do
+            it "kills nested threads when scope exits" do
+                result <- runTest $ do
+                    counter <- liftIO $ IORef.newIORef (0 :: Int)
+
+                    -- Create nested scope that will clean up its threads
+                    scoped $ do
+                        fork_ $ forever $ do
+                            liftIO $ IORef.atomicModifyIORef' counter (\n -> (n + 1, ()))
+                            threadDelay 10000
+                        -- Let it run briefly
+                        threadDelay 25000
+                    -- Inner scope exits here - thread should be KILLED
+
+                    -- Capture count after scope exit
+                    countAfter <- liftIO $ IORef.readIORef counter
+
+                    -- Wait for thread to potentially run more (it shouldn't!)
+                    threadDelay 50000
+
+                    -- Count should NOT increase after scope exit
+                    finalCount <- liftIO $ IORef.readIORef counter
+
+                    pure (countAfter, finalCount)
+
+                let (countAfter, finalCount) = result
+                -- finalCount should EQUAL countAfter (thread was cleaned up)
+                finalCount `shouldBe` countAfter
+
+
+--------------------------------------------------------------------------------
+-- Test Helpers
+--------------------------------------------------------------------------------
+
+runTest :: Eff '[Conc, Concurrent, IOE] a -> IO a
+runTest = runEff . runConcurrent . runConc


### PR DESCRIPTION
Threads forked in `collectFromPeer` were not being cleaned up when connections ended, causing a memory leak. Added `Conc.scoped` to create nested Ki scopes that automatically kill child threads on exit.

It looks like we still have a problem with memory growth but this fixes one memory issue, at least.

## Before
<img width="791" height="316" alt="image" src="https://github.com/user-attachments/assets/9940ac3c-e6cc-40db-bdda-76f440de9b5d" />
<img width="791" height="310" alt="image" src="https://github.com/user-attachments/assets/186335aa-3f8b-4f7a-9215-891f3220f6b8" />
<img width="898" height="621" alt="image(3)" src="https://github.com/user-attachments/assets/b6621a47-7cdd-4dde-b637-ad5c93ff3a35" />

Note that `Ki.Internal.IO` and `Hoard.Collector` were the biggest memory hogs.

## After
<img width="791" height="316" alt="image" src="https://github.com/user-attachments/assets/d1da5a49-eabc-48e7-b2bf-cfc7defd88ba" />
<img width="791" height="310" alt="image" src="https://github.com/user-attachments/assets/29377eb1-25e3-4f54-8163-d1279068e6b3" />
<img width="1794" height="1234" alt="image(2)" src="https://github.com/user-attachments/assets/2711c60f-dae4-4bad-a01b-691d5af74cd9" />
