### PR TITLE
refactor: remove unused "start" events for mini-protocols

### DIFF
--- a/src/Hoard/Effects/NodeToNode.hs
+++ b/src/Hoard/Effects/NodeToNode.hs
@@ -73,9 +73,6 @@ import Hoard.Effects.NodeToNode.Codecs (hoistCodecs)
 import Hoard.Effects.NodeToNode.Config (NodeToNodeConfig (..), ProtocolsConfig (..))
 import Hoard.Effects.Publishing (Pub, Sub)
 import Hoard.Effects.UUID (GenUUID)
-import Hoard.Events.ChainSync (ChainSyncIntersectionFound, ChainSyncStarted, RollBackward)
-import Hoard.Events.KeepAlive (KeepAlivePing)
-import Hoard.Events.PeerSharing (PeerSharingStarted, PeersReceived)
 import Hoard.Types.Cardano (CardanoBlock, CardanoCodecs)
 import Hoard.Types.HoardState (HoardState (..))
 import Hoard.Types.NodeIP (NodeIP (..))
@@ -87,6 +84,8 @@ import Hoard.Effects.NodeToNode.KeepAlive qualified as NodeToNode.KeepAlive
 import Hoard.Effects.NodeToNode.PeerSharing qualified as NodeToNode.PeerSharing
 import Hoard.Events.BlockFetch qualified as BlockFetch
 import Hoard.Events.ChainSync qualified as ChainSync
+import Hoard.Events.KeepAlive qualified as KeepAlive
+import Hoard.Events.PeerSharing qualified as PeerSharing
 
 
 --------------------------------------------------------------------------------
@@ -129,12 +128,10 @@ runNodeToNode
        , Pub BlockFetch.RequestFailed :> es
        , Pub BlockFetch.RequestStarted :> es
        , Pub ChainSync.HeaderReceived :> es
-       , Pub ChainSyncIntersectionFound :> es
-       , Pub ChainSyncStarted :> es
-       , Pub KeepAlivePing :> es
-       , Pub PeerSharingStarted :> es
-       , Pub PeersReceived :> es
-       , Pub RollBackward :> es
+       , Pub ChainSync.IntersectionFound :> es
+       , Pub ChainSync.RollBackward :> es
+       , Pub KeepAlive.Ping :> es
+       , Pub PeerSharing.PeersReceived :> es
        , Reader (ProtocolInfo CardanoBlock) :> es
        , Reader IOManager :> es
        , Reader NodeToNodeConfig :> es
@@ -277,12 +274,10 @@ mkApplication
        , Pub BlockFetch.RequestFailed :> es
        , Pub BlockFetch.RequestStarted :> es
        , Pub ChainSync.HeaderReceived :> es
-       , Pub ChainSyncIntersectionFound :> es
-       , Pub ChainSyncStarted :> es
-       , Pub KeepAlivePing :> es
-       , Pub PeerSharingStarted :> es
-       , Pub PeersReceived :> es
-       , Pub RollBackward :> es
+       , Pub ChainSync.IntersectionFound :> es
+       , Pub ChainSync.RollBackward :> es
+       , Pub KeepAlive.Ping :> es
+       , Pub PeerSharing.PeersReceived :> es
        , Reader ProtocolsConfig :> es
        , State HoardState :> es
        , Sub BlockFetch.Request :> es

--- a/src/Hoard/Effects/NodeToNode/BlockFetch.hs
+++ b/src/Hoard/Effects/NodeToNode/BlockFetch.hs
@@ -82,15 +82,14 @@ miniProtocol conf unlift codecs peer =
         , miniProtocolStart = StartEagerly
         , miniProtocolRun = InitiatorProtocolOnly $ mkMiniProtocolCbFromPeer $ \_ ->
             let codec = cBlockFetchCodec codecs
-                blockFetchClient = client unlift conf peer
-                tracer = nullTracer
                 wrappedPeer =
                     Peer.Effect
                         $ unlift
                         $ withExceptionLogging "BlockFetch"
-                        $ do
-                            pure $ blockFetchClientPeer blockFetchClient
-            in  (tracer, codec, wrappedPeer)
+                        $ pure
+                        $ blockFetchClientPeer
+                        $ client unlift conf peer
+            in  (nullTracer, codec, wrappedPeer)
         }
 
 

--- a/src/Hoard/Events/ChainSync.hs
+++ b/src/Hoard/Events/ChainSync.hs
@@ -1,9 +1,8 @@
 module Hoard.Events.ChainSync
-    ( ChainSyncStarted (..)
-    , HeaderReceived (..)
+    ( HeaderReceived (..)
     , RollBackward (..)
     , RollForward (..)
-    , ChainSyncIntersectionFound (..)
+    , IntersectionFound (..)
     ) where
 
 import Cardano.Api.LedgerState ()
@@ -17,13 +16,6 @@ import Hoard.Types.Cardano (CardanoHeader, CardanoPoint, CardanoTip)
 --
 -- ChainSync is responsible for synchronizing chain headers with peers,
 -- handling forks and rollbacks.
-data ChainSyncStarted = ChainSyncStarted
-    { peer :: Peer
-    , timestamp :: UTCTime
-    }
-    deriving (Show, Typeable)
-
-
 data HeaderReceived = HeaderReceived
     { peer :: Peer
     , timestamp :: UTCTime
@@ -52,7 +44,7 @@ data RollForward = RollForward
     deriving (Typeable)
 
 
-data ChainSyncIntersectionFound = ChainSyncIntersectionFound
+data IntersectionFound = IntersectionFound
     { peer :: Peer
     , timestamp :: UTCTime
     , point :: CardanoPoint

--- a/src/Hoard/Events/KeepAlive.hs
+++ b/src/Hoard/Events/KeepAlive.hs
@@ -1,5 +1,5 @@
 module Hoard.Events.KeepAlive
-    ( KeepAlivePing (..)
+    ( Ping (..)
     ) where
 
 import Data.Time (UTCTime)
@@ -7,7 +7,7 @@ import Data.Time (UTCTime)
 import Hoard.Data.Peer (Peer)
 
 
-data KeepAlivePing = KeepAlivePing
+data Ping = Ping
     { timestamp :: UTCTime
     , peer :: Peer
     }

--- a/src/Hoard/Events/PeerSharing.hs
+++ b/src/Hoard/Events/PeerSharing.hs
@@ -1,7 +1,5 @@
 module Hoard.Events.PeerSharing
-    ( PeerSharingStarted (..)
-    , PeersReceived (..)
-    , PeerSharingFailed (..)
+    ( PeersReceived (..)
     ) where
 
 import Data.Time (UTCTime)
@@ -17,24 +15,9 @@ import Hoard.Data.Peer (Peer, PeerAddress)
 --
 -- PeerSharing allows nodes to discover new peers by requesting peer addresses
 -- from connected nodes.
-data PeerSharingStarted = PeerSharingStarted
-    { peer :: Peer
-    , timestamp :: UTCTime
-    }
-    deriving (Show, Typeable)
-
-
 data PeersReceived = PeersReceived
     { peer :: Peer
     , timestamp :: UTCTime
     , peerAddresses :: Set PeerAddress -- The peer addresses we received
-    }
-    deriving (Show, Typeable)
-
-
-data PeerSharingFailed = PeerSharingFailed
-    { peer :: Peer
-    , timestamp :: UTCTime
-    , errorMessage :: Text
     }
     deriving (Show, Typeable)

--- a/src/Hoard/PeerManager.hs
+++ b/src/Hoard/PeerManager.hs
@@ -34,7 +34,6 @@ import Hoard.Effects.NodeToNode (ConnectToError (..), NodeToNode)
 import Hoard.Effects.PeerRepo (PeerRepo, updatePeerFailure)
 import Hoard.Effects.Publishing (Pub, Sub, publish)
 import Hoard.Effects.Verifier (Verifier)
-import Hoard.Events.KeepAlive (KeepAlivePing (..))
 import Hoard.PeerManager.Config (Config (..))
 import Hoard.PeerManager.Peers (Connection (..), ConnectionState (..), Peers (..), mkConnection, signalTermination)
 import Hoard.Sentry (AdversarialBehavior (..))
@@ -47,6 +46,7 @@ import Hoard.Effects.PeerRepo qualified as PeerRepo
 import Hoard.Effects.Publishing qualified as Sub
 import Hoard.Events.BlockFetch qualified as BlockFetch
 import Hoard.Events.ChainSync qualified as ChainSync
+import Hoard.Events.KeepAlive qualified as KeepAlive
 import Hoard.Sentry qualified as Sentry
 
 
@@ -73,7 +73,7 @@ component
        , Sub AdversarialBehavior :> es
        , Sub ChainSync.HeaderReceived :> es
        , Sub CullRequested :> es
-       , Sub KeepAlivePing :> es
+       , Sub KeepAlive.Ping :> es
        , Sub PeerDisconnected :> es
        , Sub PeerRequested :> es
        , Tracing :> es
@@ -131,7 +131,7 @@ triggerReplenish = do
 -- * Listeners
 
 
-updatePeerConnectionState :: (State Peers :> es) => KeepAlivePing -> Eff es ()
+updatePeerConnectionState :: (State Peers :> es) => KeepAlive.Ping -> Eff es ()
 updatePeerConnectionState event =
     modify
         $ Peers


### PR DESCRIPTION
Depends on https://github.com/tweag/cardano-hoarding-node/pull/283

Also streamlines event names to better suit usage as a qualified import.
They were all effectively named `<name-of-protocol><name-of-event>`
anyways, so changing their usages to
`<name-of-protocol>.<name-of-event>` (note the `.` in there) at least
simplifies imports and makes events less verbose where they are expected
to be front and center (like in the mini-protocol implementations
themselves).
