### PR TITLE
feat: add orphan detection config with configurable aging batch size

### DIFF
--- a/app/hoard/Main.hs
+++ b/app/hoard/Main.hs
@@ -71,6 +71,7 @@ main =
         . runConfig @"monitoring" @Monitoring.Config
         . runConfig @"cardano_protocols" @NodeToNode.ProtocolsConfig
         . runConfig @"node_to_node" @NodeToNode.NodeToNodeConfig
+        . runConfig @"orphan_detection" @OrphanDetection.Config
         . runConfig @"block_eviction" @BlockEviction.Config
         . runConfig @"cardano_node_integration" @CardanoNode.Config
         . runConfig @"node_sockets" @WithSocket.NodeSocketsConfig

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -82,6 +82,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+orphan_detection:
+  aging_batch_size: 1000
+
 block_eviction:
   eviction_interval_seconds: 3600 # 1 hour
 

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -105,6 +105,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+orphan_detection:
+  aging_batch_size: 1000
+
 block_eviction:
   eviction_interval_seconds: 3600 # 1 hour
 

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -85,6 +85,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+orphan_detection:
+  aging_batch_size: 1000
+
 block_eviction:
   eviction_interval_seconds: 3600 # 1 hour
 

--- a/config/staging.yaml
+++ b/config/staging.yaml
@@ -84,6 +84,9 @@ quota:
   entry_ttl: 43200 # 12 hours
   cleanup_interval: 3600 # 1 hour
 
+orphan_detection:
+  aging_batch_size: 1000
+
 block_eviction:
   eviction_interval_seconds: 3600 # 1 hour
 

--- a/hoard.cabal
+++ b/hoard.cabal
@@ -90,6 +90,7 @@ library
       Hoard.Listeners.NetworkEventListener
       Hoard.Monitoring
       Hoard.OrphanDetection
+      Hoard.OrphanDetection.Config
       Hoard.OrphanDetection.Data
       Hoard.OrphanDetection.Listeners
       Hoard.PeerManager

--- a/src/Hoard/OrphanDetection.hs
+++ b/src/Hoard/OrphanDetection.hs
@@ -1,6 +1,7 @@
-module Hoard.OrphanDetection (component) where
+module Hoard.OrphanDetection (component, Config (..)) where
 
 import Effectful.Error.Static (runErrorNoCallStack)
+import Effectful.Reader.Static (Reader)
 import Effectful.State.Static.Shared (State)
 
 import Hoard.Component (Component (..), defaultComponent)
@@ -12,6 +13,7 @@ import Hoard.Effects.NodeToClient (NodeToClient)
 import Hoard.Effects.Publishing (Sub)
 import Hoard.Events.BlockFetch (BlockReceived)
 import Hoard.Listeners.ImmutableTipRefreshTriggeredListener (ImmutableTipRefreshed)
+import Hoard.OrphanDetection.Config (Config (..))
 import Hoard.Types.HoardState (HoardState)
 
 import Hoard.Effects.Log qualified as Log
@@ -24,6 +26,7 @@ component
        , Clock :> es
        , Log :> es
        , NodeToClient :> es
+       , Reader Config :> es
        , State HoardState :> es
        , Sub BlockReceived :> es
        , Sub ImmutableTipRefreshed :> es

--- a/src/Hoard/OrphanDetection/Config.hs
+++ b/src/Hoard/OrphanDetection/Config.hs
@@ -1,0 +1,24 @@
+module Hoard.OrphanDetection.Config
+    ( Config (..)
+    ) where
+
+import Data.Aeson (FromJSON)
+import Data.Default (Default (..))
+
+import Hoard.Types.QuietSnake (QuietSnake (..))
+
+
+-- | Configuration for orphan detection
+data Config = Config
+    { agingBatchSize :: !Int
+    -- ^ Maximum number of unclassified blocks to age per immutable tip update.
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake Config
+
+
+instance Default Config where
+    def =
+        Config
+            { agingBatchSize = 1000
+            }


### PR DESCRIPTION
Extracts the hardcoded 1000 block limit in `immutableTipUpdatedAger` into `OrphanDetection.Config`.