### PR TITLE
feat: skip bootstrap when peers already exist in db

### DIFF
--- a/src/Hoard/Effects/PeerRepo.hs
+++ b/src/Hoard/Effects/PeerRepo.hs
@@ -3,6 +3,7 @@ module Hoard.Effects.PeerRepo
     , upsertPeers
     , getPeerByAddress
     , getAllPeers
+    , hasPeers
     , updatePeerFailure
     , updateLastConnected
     , getEligiblePeers
@@ -55,6 +56,9 @@ data PeerRepo :: Effect where
     -- | Get all peers from the database
     GetAllPeers
         :: PeerRepo m (Set Peer)
+    -- | Check if any peers exist in the database
+    HasPeers
+        :: PeerRepo m Bool
     -- | Update a peer's last failure time
     UpdatePeerFailure
         :: Peer
@@ -102,6 +106,9 @@ runPeerRepo = interpret $ \_ -> \case
     GetAllPeers ->
         withSpan "peer_repo.get_all_peers"
             $ runQuery "get-all-peers" getAllPeersImpl
+    HasPeers ->
+        withSpan "peer_repo.has_peers"
+            $ runQuery "has-peers" hasPeersImpl
     UpdatePeerFailure peer timestamp ->
         withSpan "peer_repo.update_peer_failure"
             $ runTransaction "update-peer-failure"
@@ -185,6 +192,16 @@ getAllPeersImpl =
     fmap (fromList . map PeersSchema.peerFromRow)
         $ Rel8.run
         $ select
+        $ Rel8.each PeersSchema.schema
+
+
+-- | Check if any peers exist in the database
+hasPeersImpl :: Statement () Bool
+hasPeersImpl =
+    fmap (not . null)
+        $ Rel8.run
+        $ select
+        $ Rel8.limit 1
         $ Rel8.each PeersSchema.schema
 
 

--- a/src/Hoard/PeerManager.hs
+++ b/src/Hoard/PeerManager.hs
@@ -41,6 +41,7 @@ import Hoard.Types.Environment (PeerSnapshotFile)
 
 import Hoard.Effects.Clock qualified as Clock
 import Hoard.Effects.Conc qualified as Conc
+import Hoard.Effects.Log qualified as Log
 import Hoard.Effects.PeerRepo qualified as PeerRepo
 import Hoard.Effects.Publishing qualified as Sub
 import Hoard.Events.BlockFetch qualified as BlockFetch
@@ -82,8 +83,14 @@ component
 component =
     defaultComponent
         { name = "PeerManager"
-        , setup =
-            void bootstrapPeers
+        , setup = do
+            knownPeersExist <- PeerRepo.hasPeers
+            if knownPeersExist then
+                Log.debug "Known peers found in database, skipping bootstrap"
+            else do
+                Log.debug "No known peers found, bootstrapping from peer snapshot"
+                bootstrappedPeers <- bootstrapPeers
+                Log.debug $ "Bootstrapped " <> show (Set.size bootstrappedPeers) <> " peers from peer snapshot"
         , listeners =
             pure
                 [ Sub.listen updatePeerConnectionState


### PR DESCRIPTION
Depends on #294

Add `PeerRepo.hasPeers` and use it in `PeerManager` setup to only bootstrap from the peer snapshot when the database has no known peers.