### PR TITLE
fix: correct rtsopts flag syntax for -N and -T

### DIFF
--- a/hoard.cabal
+++ b/hoard.cabal
@@ -258,7 +258,7 @@ executable hoard-exe
       StrictData
       TemplateHaskell
       TypeFamilies
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -O0 -fplugin=Effectful.Plugin -threaded -with-rtsopts=-NT
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -O0 -fplugin=Effectful.Plugin -threaded "-with-rtsopts=-N -T"
   build-depends:
       base
     , data-default

--- a/package.yaml
+++ b/package.yaml
@@ -125,7 +125,7 @@ executables:
     main:                Main.hs
     source-dirs:         app/hoard
     ghc-options:
-    - -with-rtsopts=-NT
+    - '"-with-rtsopts=-N -T"'
     dependencies:
     - name: base
       mixin:


### PR DESCRIPTION
Use a quoted string "-with-rtsopts=-N -T" so both options are passed correctly. Multiple separate -with-rtsopts flags don't accumulate [GHC #18117](https://gitlab.haskell.org/ghc/ghc/-/issues/18117).