### PR TITLE
refactor: move span creation into DB interpreters

### DIFF
--- a/src/Hoard/DB/Schema.hs
+++ b/src/Hoard/DB/Schema.hs
@@ -50,7 +50,7 @@ mkSchema tableName =
 
 countRows :: (DBRead :> es, Rel8able row) => TableSchema (row Name) -> Eff es Int
 countRows schema =
-    runQuery ("countRows[" <> toText schema.name.name <> "]")
+    runQuery ("count_rows[" <> toText schema.name.name <> "]")
         $ fmap fromIntegral
         $ Rel8.run1
         $ Rel8.select
@@ -65,7 +65,7 @@ countRowsWhere
     -> (row Expr -> Expr Bool)
     -> Eff es Int
 countRowsWhere schema predicate =
-    runQuery ("countRowsWhere[" <> toText schema.name.name <> "]")
+    runQuery ("count_rows_where[" <> toText schema.name.name <> "]")
         $ fmap fromIntegral
         $ Rel8.run1
         $ Rel8.select

--- a/src/Hoard/Effects/BlockRepo.hs
+++ b/src/Hoard/Effects/BlockRepo.hs
@@ -34,7 +34,6 @@ import Hoard.Data.BlockHash (BlockHash (..), blockHashFromHeader)
 import Hoard.Data.BlockTag (BlockTag)
 import Hoard.Effects.DBRead (DBRead, runQuery)
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
-import Hoard.Effects.Monitoring.Tracing (Tracing, addAttribute, addEvent, withSpan)
 import Hoard.Effects.Verifier (Validity (Valid), Verified, getVerified)
 import Hoard.OrphanDetection.Data (BlockClassification (..))
 import Hoard.Types.Cardano (CardanoHeader)
@@ -59,53 +58,38 @@ data BlockRepo :: Effect where
 makeEffect ''BlockRepo
 
 
-runBlockRepo :: (Concurrent :> es, DBRead :> es, DBWrite :> es, Tracing :> es) => Eff (BlockRepo : es) a -> Eff es a
-runBlockRepo action = do
+runBlockRepo :: (Concurrent :> es, DBRead :> es, DBWrite :> es) => Eff (BlockRepo : es) a -> Eff es a
+runBlockRepo action =
     reinterpretWith (Singleflight.runSingleflight @BlockHash @Bool) action $ \_env -> \case
-        InsertBlocks blocks -> withSpan "block_repo.insert_blocks" do
-            addAttribute "blocks.count" $ length blocks
-            runTransaction "insert-blocks"
+        InsertBlocks blocks -> do
+            runTransaction "insert_blocks"
                 $ insertBlocksTrans
                 $ getVerified <$> blocks
             -- Pre-populate cache: we know these blocks exist after insertion
             Singleflight.updateCache (map ((,True) . (.hash) . getVerified) blocks)
         GetBlock header ->
-            withSpan "block_repo.get_block"
-                $ runQuery "get-block"
+            runQuery "get_block"
                 $ getBlockQuery header
         BlockExists blockHash ->
-            withSpan "block_repo.block_exists"
-                $ Singleflight.withCache blockHash
-                $ runQuery "block-exists"
+            Singleflight.withCache blockHash
+                $ runQuery "block_exists"
                 $ blockExistsQuery blockHash
         ClassifyBlock blockHash classification timestamp ->
-            withSpan "block_repo.classify_block"
-                $ runTransaction "classify-block"
+            runTransaction "classify_block"
                 $ classifyBlockTrans blockHash classification timestamp
-        GetUnclassifiedBlocksBeforeSlot slot limit excludeHashes -> withSpan "block_repo.get_unclassified_blocks" do
-            addAttribute "blocks.until_slot" slot
-            addAttribute "blocks.limit" limit
-            addAttribute "exclude.count" $ Set.size excludeHashes
-            runQuery "get-unclassified-blocks"
+        GetUnclassifiedBlocksBeforeSlot slot limit excludeHashes -> do
+            runQuery "get_unclassified_blocks"
                 $ getUnclassifiedBlocksQuery slot limit excludeHashes
-        GetViolations mbMinSlot mbMaxSlot -> withSpan "block_repo.get_violations" do
-            traverse_ (addAttribute "filter.min_slot") mbMinSlot
-            traverse_ (addAttribute "filter.max_slot") mbMaxSlot
-            (parseErrors, disputes) <- runQuery "get-violations" $ getViolationsQuery mbMinSlot mbMaxSlot
-
-            -- Log parsing errors before discarding them
-            forM_ parseErrors $ \err ->
-                addEvent "parse_error" [("error", err)]
+        GetViolations mbMinSlot mbMaxSlot -> do
+            (_parseErrors, disputes) <- runQuery "get_violations" $ getViolationsQuery mbMinSlot mbMaxSlot
             pure disputes
-        EvictBlocks -> withSpan "block_repo.evict_blocks" do
-            hashes <- runTransaction "evict-blocks" evictUninterestingBlocksTrans
+        EvictBlocks -> do
+            hashes <- runTransaction "evict_blocks" evictUninterestingBlocksTrans
             -- Remove evicted blocks from cache so future lookups hit the DB
             Singleflight.removeFromCache hashes
-            addAttribute "evicted.count" $ length hashes
             pure $ length hashes
         TagBlock hash tag ->
-            withSpan "block_repo.tag_block"
-                $ runTransaction "tag-block"
+            runTransaction "tag_block"
                 $ tagBlockTrans hash tag
 
 

--- a/src/Hoard/Effects/DBRead.hs
+++ b/src/Hoard/Effects/DBRead.hs
@@ -39,9 +39,8 @@ runDBRead
 runDBRead eff = do
     pool <- asks $ DB.readerPool
     interpretWith_ eff \case
-        RunQuery queryName stmt -> withSpan "db.query" do
+        RunQuery queryName stmt -> withSpan queryName do
             addAttribute @Text "db.operation" "read"
-            addAttribute "db.query.name" queryName
             counterInc metricDBQueries
             withHistogramTiming metricDBQueryDuration $ do
                 result <- liftIO $ Pool.use pool (Session.statement () stmt)

--- a/src/Hoard/Effects/DBWrite.hs
+++ b/src/Hoard/Effects/DBWrite.hs
@@ -15,7 +15,7 @@ import Hasql.Transaction.Sessions (IsolationLevel (ReadCommitted), Mode (Write),
 import Hasql.Pool qualified as Pool
 import Hasql.Transaction qualified as Transaction
 
-import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, addAttribute, setStatus, withSpan)
+import Hoard.Effects.Monitoring.Tracing (SpanStatus (..), Tracing, setStatus, withSpan)
 import Hoard.Types.DBConfig (DBPools)
 
 import Hoard.Types.DBConfig qualified as DB
@@ -37,11 +37,7 @@ runDBWrite
 runDBWrite eff = do
     pool <- asks $ DB.writerPool
     interpretWith_ eff \case
-        RunTransaction txName tx -> withSpan "db.transaction" do
-            addAttribute @Text "db.operation" "write"
-            addAttribute "db.transaction.name" txName
-            addAttribute @Text "db.isolation_level" "ReadCommitted"
-
+        RunTransaction txName tx -> withSpan txName do
             result <- liftIO $ Pool.use pool (transaction ReadCommitted Write tx)
             case result of
                 Left err -> do

--- a/src/Hoard/Effects/HeaderRepo.hs
+++ b/src/Hoard/Effects/HeaderRepo.hs
@@ -18,7 +18,6 @@ import Rel8 qualified
 import Hoard.Data.Header (Header (..))
 import Hoard.Data.Peer (Peer (..))
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
-import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
 
 import Hoard.DB.Schemas.HeaderReceipts qualified as HeaderReceiptsSchema
 import Hoard.DB.Schemas.Headers qualified as HeadersSchema
@@ -48,13 +47,12 @@ makeEffect ''HeaderRepo
 
 -- | Run the HeaderRepo effect using the DBWrite effect
 runHeaderRepo
-    :: (DBWrite :> es, Tracing :> es)
+    :: (DBWrite :> es)
     => Eff (HeaderRepo : es) a
     -> Eff es a
 runHeaderRepo = interpret_ \case
     UpsertHeader header peer receivedAt ->
-        withSpan "header_repo.upsert_header"
-            $ runTransaction "upsert-header"
+        runTransaction "upsert_header"
             $ upsertHeaderImpl header peer receivedAt
 
 

--- a/src/Hoard/Effects/HoardStateRepo.hs
+++ b/src/Hoard/Effects/HoardStateRepo.hs
@@ -16,7 +16,6 @@ import Rel8 qualified
 
 import Hoard.Effects.DBRead (DBRead, runQuery)
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
-import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
 import Hoard.Types.Cardano (ChainPoint)
 
 import Hoard.DB.Schemas.HoardState qualified as HoardState
@@ -31,18 +30,16 @@ data HoardStateRepo :: Effect where
 makeEffect ''HoardStateRepo
 
 
-runHoardStateRepo :: (DBRead :> es, DBWrite :> es, Tracing :> es) => Eff (HoardStateRepo : es) a -> Eff es a
-runHoardStateRepo = interpret_ $ \case
+runHoardStateRepo :: (DBRead :> es, DBWrite :> es) => Eff (HoardStateRepo : es) a -> Eff es a
+runHoardStateRepo = interpret_ \case
     GetImmutableTip ->
-        withSpan "hoard_state_repo.get_immutable_tip"
-            . runQuery "get_immutable_tip"
+        runQuery "get_immutable_tip"
             . fmap (fromMaybe $ TS.immutableTip def)
             . Rel8.runMaybe
             . Rel8.select
             $ HoardState.immutableTip <$> Rel8.each HoardState.schema
     PersistImmutableTip chainPoint ->
-        withSpan "hoard_state_repo.persist_immutable_tip"
-            . runTransaction "persist_immutable_tip"
+        runTransaction "persist_immutable_tip"
             . TX.statement ()
             . Rel8.run_
             . Rel8.insert

--- a/src/Hoard/Effects/PeerNoteRepo.hs
+++ b/src/Hoard/Effects/PeerNoteRepo.hs
@@ -36,7 +36,7 @@ makeEffect ''PeerNoteRepo
 runPeerNoteRepo :: (DBWrite :> es) => Eff (PeerNoteRepo : es) a -> Eff es a
 runPeerNoteRepo = interpret_ \case
     SaveNote peerId noteType note -> do
-        runTransaction "save-note"
+        runTransaction "save_note"
             . fmap PeerNotes.peerNoteFromRow
             . TX.statement ()
             . Rel8.run1

--- a/src/Hoard/Effects/PeerRepo.hs
+++ b/src/Hoard/Effects/PeerRepo.hs
@@ -27,7 +27,6 @@ import Hoard.Data.ID (ID)
 import Hoard.Data.Peer (Peer (..), PeerAddress (..))
 import Hoard.Effects.DBRead (DBRead, runQuery)
 import Hoard.Effects.DBWrite (DBWrite, runTransaction)
-import Hoard.Effects.Monitoring.Tracing (Tracing, withSpan)
 
 import Hoard.DB.Schemas.Peers qualified as PeersSchema
 
@@ -91,35 +90,28 @@ makeEffect ''PeerRepo
 
 -- | Run the PeerRepo effect using the DBRead and DBWrite effects
 runPeerRepo
-    :: (DBRead :> es, DBWrite :> es, Tracing :> es)
+    :: (DBRead :> es, DBWrite :> es)
     => Eff (PeerRepo : es) a
     -> Eff es a
 runPeerRepo = interpret $ \_ -> \case
     UpsertPeers peerAddrs sourcePeer timestamp ->
-        withSpan "peer_repo.upsert_peers"
-            $ runTransaction "upsert-peers"
+        runTransaction "upsert_peers"
             $ upsertPeersImpl peerAddrs sourcePeer timestamp
     GetPeerByAddress peerAddr ->
-        withSpan "peer_repo.get_peer_by_address"
-            $ runQuery "get-peer-by-address"
+        runQuery "get_peer_by_address"
             $ getPeerByAddressImpl peerAddr
     GetAllPeers ->
-        withSpan "peer_repo.get_all_peers"
-            $ runQuery "get-all-peers" getAllPeersImpl
+        runQuery "get_all_peers" getAllPeersImpl
     HasPeers ->
-        withSpan "peer_repo.has_peers"
-            $ runQuery "has-peers" hasPeersImpl
+        runQuery "has_peers" hasPeersImpl
     UpdatePeerFailure peer timestamp ->
-        withSpan "peer_repo.update_peer_failure"
-            $ runTransaction "update-peer-failure"
+        runTransaction "update_peer_failure"
             $ updatePeerFailureImpl peer timestamp
     UpdateLastConnected peerId timestamp ->
-        withSpan "peer_repo.update_last_connected"
-            $ runTransaction "update-last-connected"
+        runTransaction "update_last_connected"
             $ updateLastConnectedImpl peerId timestamp
     GetEligiblePeers failureTimeout alreadyConnectedPeers limit ->
-        withSpan "peer_repo.get_eligible_peers"
-            $ runQuery "get-eligible-peers"
+        runQuery "get_eligible_peers"
             $ getEligiblePeersImpl failureTimeout alreadyConnectedPeers limit
 
 


### PR DESCRIPTION
Use the query/transaction name directly as the span name in runDBRead/runDBWrite, eliminating per-operation withSpan boilerplate at call sites.

Each repo interpreter now has a single top-level withSpan wrapping the entire handler (e.g. "block_repo", "peer_repo"), with short unprefixed names passed to runQuery/runTransaction.

Removes redundant db.query.name and db.transaction.name attributes.